### PR TITLE
docs: 更新README.md并添加Ubuntu24.04安装第三方pip包的方法

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -34,6 +34,8 @@ pip3 install python-can
 
 ## 1.2 安装 pyAgxArm
 
+[在Ubuntu24.04安装第三方pip包的方法](./docs/Ubuntu24.04安装第三方pip包的方法.MD)
+
 注意是否在conda环境里
 
 ```bash

--- a/docs/Ubuntu24.04安装第三方pip包的方法.MD
+++ b/docs/Ubuntu24.04安装第三方pip包的方法.MD
@@ -1,0 +1,62 @@
+# Ubuntu24.04安装第三方pip包的方法.MD
+
+根据在系统环境下执行pip3 install piper_sdk给出的报错提示，现在的版本，使用官方python3.12-venv创建的虚拟环境，然后在虚拟环境中安装piper_sdk是可以的
+
+Based on the error message from executing `pip3 install piper_sdk` in the system environment, in the current version, it is possible to install `piper_sdk` within a virtual environment created using the official Python 3.12-venv.
+
+```bash
+sudo apt install python3-pip
+```
+
+```bash
+sudo apt install python3.12-venv
+```
+
+```bash
+python3 -m venv ~/venv
+```
+
+```bash
+source ~/venv/bin/activate
+```
+
+```bash
+pip install pyAgxArm
+```
+
+你也可以强制安装
+
+You can also force installation
+
+通过添加 --break-system-packages 标志来绕过。
+
+Bypass this by adding the `--break-system-packages` flag.
+
+```bash
+pip install --user pyAgxArm --break-system-packages
+```
+
+无需每次运行 pip install 命令时都键入 --break-system-packages，您可以将规则写入配置文件：
+
+Instead of typing `--break-system-packages` every time you run the `pip install` command, you can write the rules to a configuration file:
+
+```bash
+mkdir -p ~/.config/pip
+```
+
+```bash
+echo -e "[global]\nbreak-system-packages=true" > ~/.config/pip/pip.conf
+```
+
+这些命令将首先创建 ~/.config/pip 文件夹（如果不存在），然后创建 pip.conf 配置文件并将以下行写入其中：
+
+These commands will first create the ~/.config/pip folder (if it does not exist), then create the pip.conf configuration file and add the following line to it:
+
+```bash
+[global]
+break-system-packages=true
+```
+
+之后，您可以使用 pip install 命令安装包，就像在 Ubuntu 22.04 及更早版本中一样
+
+Afterwards, you can install packages using the `pip install` command, just like in Ubuntu 22.04 and earlier.

--- a/docs/nero/nero-API使用文档.MD
+++ b/docs/nero/nero-API使用文档.MD
@@ -25,7 +25,7 @@ create_agx_arm_config(
 |名称|类型|说明|
 |---|---|---|
 |robot|str|["nero","piper","piper_h","piper_l","piper_x"]参数可选，选择预期创建的机械臂实例|
-|comm|str|["can"]可选，选择连接机械臂的通讯方式|
+|comm|str|["can"]可选，默认为`"can0`"，选择连接机械臂的通讯方式|
 |firmeware_version|str|默认为"default"，选择机械臂当前底层对应的主控固件版本|
 |---可选参数---|||
 |joint_limit|dict|默认可以不输入，程序内自动根据机械臂赋值指定的关节限位，如果要指定，需要手动输入dict类型的关节限位，单位：弧度，示例下文可见，暂时不会对手动输入的关节限位生效到实际控制中|

--- a/docs/piper/piper-API使用文档.MD
+++ b/docs/piper/piper-API使用文档.MD
@@ -25,7 +25,7 @@ create_agx_arm_config(
 |名称|类型|说明|
 |---|---|---|
 |robot|str|["nero","piper","piper_h","piper_l","piper_x"]参数可选，选择预期创建的机械臂实例|
-|comm|str|["can"]可选，选择连接机械臂的通讯方式|
+|comm|str|["can"]可选，默认为`"can0`"，选择连接机械臂的通讯方式|
 |firmeware_version|str|默认为"default"，选择机械臂当前底层对应的主控固件版本|
 |---可选参数---|||
 |joint_limit|dict|默认可以不输入，程序内自动根据机械臂赋值指定的关节限位，如果要指定，需要手动输入dict类型的关节限位，单位：弧度，示例下文可见，暂时不会对手动输入的关节限位生效到实际控制中|


### PR DESCRIPTION
在README.md中添加了Ubuntu24.04安装第三方pip包的方法的链接。

更新了nero-API和piper-API文档中`create_agx_arm_config`函数的`comm`参数说明，添加了默认值`"can0"`，并更新了示例说明。