### PR TITLE
feat(pyAgxArm): 添加ArmMsgFeedbackStatus类的_fields_属性

### DIFF
--- a/pyAgxArm/protocols/can_protocol/msgs/nero/default/feedback/arm_feedback_status.py
+++ b/pyAgxArm/protocols/can_protocol/msgs/nero/default/feedback/arm_feedback_status.py
@@ -235,7 +235,15 @@ class ArmMsgFeedbackStatus(AttributeBase):
             bit[6]: Joint 7 communication exception (0: normal, 1: abnormal)
             bit[7]: Reserved
     '''
-    
+    _fields_ = (
+        "ctrl_mode",
+        "arm_status",
+        "mode_feedback",
+        "teach_status",
+        "motion_status",
+        "trajectory_num",
+        "err_status",
+    )
     def __init__(self,
                  ctrl_mode: int = 0,
                  arm_status: int = 0,


### PR DESCRIPTION
添加了ArmMsgFeedbackStatus类的_fields_属性，用于打印

_fields_属性包括以下字段：
- ctrl_mode: 控制模式
- arm_status: 机械臂状态
- mode_feedback: 模式反馈
- teach_status: 示教状态
- motion_status: 运动状态
- trajectory_num: 轨迹编号
- err_status: 错误状态