### PR TITLE
fix: 修正类型引用，以兼容python3.6特性

### DIFF
--- a/pyAgxArm/protocols/can_protocol/drivers/nero/default/parser.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/nero/default/parser.py
@@ -60,11 +60,11 @@ class NeroDefaultDriverAPIProtoAdapter(DriverAPIProtoAdapter):
     }
 
     @classmethod
-    def motion_mode(cls, value: str) -> tuple[int, int]:
+    def motion_mode(cls, value: str) -> Tuple[int, int]:
         return cls._MOVE_CODE[value]
     
     @classmethod
-    def mit_mode(cls, value: str) -> tuple[int, int]:
+    def mit_mode(cls, value: str) -> Tuple[int, int]:
         return cls._MIT_CODE.get(value, ArmMsgModeCtrl.Enums.MitMode.POS_VEL)
 
 class Codec(PiperCodec):

--- a/pyAgxArm/protocols/can_protocol/drivers/piper/default/parser.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/piper/default/parser.py
@@ -66,11 +66,11 @@ class PiperDefaultDriverAPIProtoAdapter(DriverAPIProtoAdapter):
         return cls._INSTALL_POS_CODE[value]
 
     @classmethod
-    def motion_mode(cls, value: str) -> tuple[int, int]:
+    def motion_mode(cls, value: str) -> Tuple[int, int]:
         return cls._MOVE_CODE[value]
     
     @classmethod
-    def mit_mode(cls, value: str) -> tuple[int, int]:
+    def mit_mode(cls, value: str) -> Tuple[int, int]:
         return cls._MIT_CODE.get(value, ArmMsgModeCtrl.Enums.MitMode.POS_VEL)
 
     @classmethod

--- a/pyAgxArm/protocols/can_protocol/msgs/effector/agx_gripper/default/transmit/arm_gripper_ctrl.py
+++ b/pyAgxArm/protocols/can_protocol/msgs/effector/agx_gripper/default/transmit/arm_gripper_ctrl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-from typing_extensions import Literal, Union
+from typing import Union
+from typing_extensions import Literal
 
 from .....core.attritube_base import AttributeBase
 


### PR DESCRIPTION
fix: 修正类型引用，以兼容python3.6特性

修复了 `motion_mode` 和 `mit_mode` 方法的返回值类型注解，将 `tuple[int, int]` 修改为 `Tuple[int, int]`。

修复了 `arm_gripper_ctrl.py` 文件，将 `from typing_extensions import Literal, Union` 修改为 `from typing import Union` 和 `from typing_extensions import Literal` 

---
Fix: Corrected type references for compatibility with Python 3.6 features.

Fixed the return type annotations for the `motion_mode` and `mit_mode` methods, changing `tuple[int, int]` to `Tuple[int, int]`.

Fixed the `arm_gripper_ctrl.py` file, changing `from typing_extensions import Literal, Union` to `from typing import Union` and `from typing_extensions import Literal`.