### PR TITLE
feat(effector): 新增 Revo2 Touch 触觉手驱动与腕部 CAN FD 隧道

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | Nero API | [docs/nero/nero_api.md](./docs/nero/nero_api.md#nero-api-documentation) |
 | AgxGripper API | [docs/effector/agx_gripper/agx_gripper_api.md](./docs/effector/agx_gripper/agx_gripper_api.md#agxgripper-api-documentation) |
 | Revo2 API | [docs/effector/revo2/revo2_api.md](./docs/effector/revo2/revo2_api.md#revo2-api-documentation) |
+| Revo2 Touch API | [docs/effector/revo2_touch/revo2_touch_api.md](./docs/effector/revo2_touch/revo2_touch_api.md#revo2-touch-api-documentation) |
 | CAN module manual | [docs/can_user.md](./docs/can_user.md#can-module-manual) |
 | Nero first-time CAN guide | [docs/nero/first_time_user_guide_can.md](./docs/nero/first_time_user_guide_can.md#nero-first-time-user-guide-can) |
 | WSL2 USB-CAN guide | [docs/wsl2_usb_can_guide.md](./docs/wsl2_usb_can_guide.md#wsl2-ubuntu-2204-complete-usb-can-setup-guide) |
@@ -170,6 +171,7 @@ while True:
 | Nero API | [docs/nero/nero_api.md](./docs/nero/nero_api.md#nero-机械臂-api-使用文档) |
 | AgxGripper API | [docs/effector/agx_gripper/agx_gripper_api.md](./docs/effector/agx_gripper/agx_gripper_api.md#agxgripper-夹爪-api-使用文档) |
 | Revo2 API | [docs/effector/revo2/revo2_api.md](./docs/effector/revo2/revo2_api.md#revo2-灵巧手-api-使用文档) |
+| Revo2 Touch API | [docs/effector/revo2_touch/revo2_touch_api.md](./docs/effector/revo2_touch/revo2_touch_api.md#revo2-touch-灵巧手-api-使用文档) |
 | CAN 模块手册 | [docs/can_user.md](./docs/can_user.md#can-模块使用手册) |
 | Nero 首次使用 CAN 指南 | [docs/nero/first_time_user_guide_can.md](./docs/nero/first_time_user_guide_can.md#nero-首次使用指南can) |
 | WSL2 USB-CAN 使用指南 | [docs/wsl2_usb_can_guide.md](./docs/wsl2_usb_can_guide.md#wsl2-ubuntu-2204-连接-usb-can-模块完整指南) |

--- a/docs/effector/revo2_touch/revo2_touch_api.md
+++ b/docs/effector/revo2_touch/revo2_touch_api.md
@@ -1,0 +1,625 @@
+# Revo2 Touch API Documentation
+
+> This document describes the **Revo2 Touch** capacitive tactile hand Python API (based on **`bc-stark-sdk`**).
+
+> **Note:** This driver bridges the official Revo2 hand SDK. For the full SDK API and usage, see [Advanced: run_sdk and client](#advanced-run_sdk-and-client).
+
+- [Switch to 中文](#revo2-touch-灵巧手-api-使用文档)
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Value Ranges and Finger Order](#value-ranges-and-finger-order)
+- [Create Instance and Connect](#create-instance-and-connect)
+- [Hand-Side Routing](#hand-side-routing)
+- [SDK Types on the Driver](#sdk-types-on-the-driver)
+- [Device Information](#device-information)
+- [Device Configuration](#device-configuration)
+- [Finger Motion Control](#finger-motion-control)
+- [Motor Status and Settings](#motor-status-and-settings)
+- [Capacitive Touch](#capacitive-touch)
+- [LED / Buzzer / Vibration](#led--buzzer--vibration)
+- [Device Discovery](#device-discovery)
+- [Advanced: run_sdk and client](#advanced-run_sdk-and-client)
+- [API Index](#api-index)
+
+---
+
+## Overview
+
+Initialize Revo2 Touch:
+
+```python
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+```
+
+> The driver wraps **bc-stark-sdk** and communicates with the hand through the conversion board.
+
+Read APIs often return `None` on failure; write APIs fail silently via `run_sdk` on timeout or error.
+
+---
+
+## Prerequisites
+
+1. **Hardware (required):** **Revo2 Touch** hand connected to the **arm bus through the Agilex conversion board**
+2. **Connection:** Same bus / channel as the arm — see [CAN module manual](../../can_user.md)
+3. **Python package:**
+
+```bash
+pip install bc-stark-sdk
+```
+
+4. **Read loop:** Call `robot.connect()` so the arm can send and receive hand data normally
+
+---
+
+## Quick Start
+
+**Nero example:**
+
+```python
+from pyAgxArm import AgxArmFactory, ArmModel, NeroFW, create_agx_arm_config
+
+cfg = create_agx_arm_config(
+    robot=ArmModel.NERO,
+    firmeware_version=NeroFW.V112,
+    channel="can0",
+)
+robot = AgxArmFactory.create_arm(cfg)
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+**Piper example** (same effector API; only arm config differs):
+
+```python
+from pyAgxArm import AgxArmFactory, ArmModel, PiperFW, create_agx_arm_config
+
+cfg = create_agx_arm_config(
+    robot=ArmModel.PIPER,
+    firmeware_version=PiperFW.V188,
+    channel="can0",
+)
+robot = AgxArmFactory.create_arm(cfg)
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+Common usage after connect:
+
+```python
+hand.set_hand_side("right")  # optional; default auto-detects left/right
+
+info = hand.get_device_info()
+if info is not None:
+    print(info.description)
+
+item = hand.get_single_touch_sensor_status(1)
+if item is not None:
+    print(item.description)
+
+hand.set_finger_positions([500] * 6)
+
+robot.disconnect()
+```
+
+---
+
+## Value Ranges and Finger Order
+
+**Finger array order (length 6):** Thumb Flex, Thumb Aux, Index, Middle, Ring, Pinky — use `hand.FingerId.*`.
+
+**Unified ranges (SDK):**
+
+| Quantity | Range | Notes |
+| --- | --- | --- |
+| Position | 0 ~ 1000 | 0 = open, 1000 = closed |
+| Speed | -1000 ~ +1000 | + close, − open, 0 = stop |
+| Current | -1000 ~ +1000 | + close, − open |
+| Duration (Revo2) | 1 ~ 2000 ms | Per-finger or batch APIs |
+
+---
+
+## Create Instance and Connect
+
+```python
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+**`EFFECTOR` constant:**
+
+```python
+REVO2_TOUCH: Final[Literal["revo2_touch"]] = "revo2_touch"
+```
+
+> **Notes:**
+> 1. Call `init_effector` only once per arm session.
+> 2. Create the effector before `connect()` (recommended).
+> 3. **Prerequisite:** Revo2 Touch connected to the arm bus through the Agilex conversion board.
+
+---
+
+## Hand-Side Routing
+
+### Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `hand.hand_side` | `str \| None` | `"left"`, `"right"`, or `None` before auto-bind |
+| `hand.slave_id` | `int \| None` | Bound hand device id, or `None` if not yet known |
+| `hand.client` | `DeviceContext` | Raw bc-stark-sdk context (advanced) |
+
+### `set_hand_side(side=None)`
+
+| Parameter | Description |
+| --- | --- |
+| `"left"` / `"right"` | Pin routing; no failover |
+| `None` | Auto mode: detect left/right hand, bind first responder, failover on error |
+
+```python
+hand.set_hand_side("right")   # pin right
+hand.set_hand_side(None)      # back to auto
+```
+
+---
+
+## SDK Types on the Driver
+
+Re-exported on the driver class (no separate import needed):
+
+| Attribute | Use |
+| --- | --- |
+| `hand.FingerId` | `Thumb`, `ThumbAux`, `Index`, `Middle`, `Ring`, `Pinky` |
+| `hand.FingerUnitMode` | `Normalized`, `Physical` |
+| `hand.LedColor` | `RGB`, `R`, `G`, `B`, … |
+| `hand.LedMode` | `Blink`, `Blink2Hz`, `Keep`, … |
+| `hand.LedInfo` | LED configuration object |
+| `hand.MotorSettings` | Per-finger motor limits |
+
+---
+
+## Device Information
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `get_device_info()` | `DeviceInfo \| None` | SN, firmware, hardware type — **call once after connect** |
+| `get_device_sn()` | `str \| None` | Serial number |
+| `get_device_fw_version()` | `str \| None` | Firmware string |
+| `get_sku_type()` | `SkuType \| None` | SKU / hand side |
+| `get_hand_type()` | `HandType \| None` | Left / right enum |
+| `get_button_event()` | `ButtonPressEvent \| None` | Physical button event |
+
+```python
+info = hand.get_device_info()
+if info is not None:
+    print(info.serial_number, info.firmware_version, info.hardware_type)
+```
+
+---
+
+## Device Configuration
+
+| Method | Description |
+| --- | --- |
+| `get_auto_calibration_enabled()` → `bool \| None` | Query auto-calibration |
+| `set_auto_calibration(enabled: bool)` | Enable / disable auto-calibration |
+| `calibrate_position()` | Trigger manual position calibration |
+| `reset_default_settings()` | Factory reset settings |
+| `reboot()` | Reboot the hand |
+
+---
+
+## Finger Motion Control
+
+### Single finger
+
+| Method | Description |
+| --- | --- |
+| `set_finger_position(finger_id, position)` | Position 0~1000 |
+| `set_finger_position_with_millis(finger_id, position, ms)` | Position + duration (Revo2) |
+| `set_finger_position_with_speed(finger_id, position, speed)` | Position + speed (Revo2) |
+| `set_finger_speed(finger_id, speed)` | Speed −1000~+1000 |
+| `set_finger_current(finger_id, current)` | Current −1000~+1000 |
+
+### All fingers (arrays length 6)
+
+| Method | Description |
+| --- | --- |
+| `set_finger_positions(positions)` | Six positions |
+| `set_finger_positions_and_durations(positions, durations)` | Six positions + six durations (Revo2) |
+| `set_finger_positions_and_speeds(positions, speeds)` | Six positions + six speeds (Revo2) |
+| `set_finger_speeds(speeds)` | Six speeds |
+| `set_finger_currents(currents)` | Six currents |
+
+### Readbacks
+
+| Method | Returns |
+| --- | --- |
+| `get_finger_positions()` | `list[int] \| None` |
+| `get_finger_speeds()` | `list[int] \| None` |
+| `get_finger_currents()` | `list[int] \| None` |
+
+```python
+hand.set_finger_position(hand.FingerId.Index, 500)
+hand.set_finger_positions_and_speeds([1000] * 6, [300] * 6)
+pos = hand.get_finger_positions()
+```
+
+---
+
+## Motor Status and Settings
+
+| Method | Returns / action |
+| --- | --- |
+| `get_motor_status()` | `MotorStatusData \| None` (positions, speeds, currents, states) |
+| `get_motor_state()` | `list[int] \| None` — running / idle / stalled codes |
+| `get_finger_unit_mode()` / `set_finger_unit_mode(mode)` | Revo2 unit mode |
+| `get_all_finger_settings()` | `list[MotorSettings] \| None` |
+| `get_finger_settings(finger_id)` / `set_finger_settings(finger_id, settings)` | Per-finger settings |
+| `get/set_finger_min_position(finger_id, …)` | Limit min position |
+| `get/set_finger_max_position(finger_id, …)` | Limit max position |
+| `get/set_finger_max_speed(finger_id, …)` | Limit max speed |
+| `get/set_finger_max_current(finger_id, …)` | Limit max current |
+| `get/set_finger_protected_current(finger_id, …)` | Stall-detection threshold (single) |
+| `get_finger_protected_currents()` / `set_finger_protected_currents(currents)` | Stall threshold (all) |
+| `get/set_thumb_aux_lock_current(lock_current)` | Thumb auxiliary lock current |
+
+---
+
+## Capacitive Touch
+
+Revo2 Touch exposes **capacitive** tactile data (not Force3D / array pressure — use `run_sdk` for unwrapped SDK features if needed).
+
+| Method | Description |
+| --- | --- |
+| `get_touch_sensor_enabled()` | Which fingertip sensors are enabled |
+| `get_touch_sensor_fw_versions()` | Firmware version string per sensor |
+| `get_touch_sensor_raw_data()` | `TouchRawData \| None` |
+| `get_touch_sensor_status()` | `list[TouchFingerItem] \| None` — all fingers |
+| `get_single_touch_sensor_status(index)` | One finger, `index` 0–4 |
+| `touch_sensor_setup(enable_mask)` | Enable selected sensors |
+| `touch_sensor_reset(reset_mask)` | Reset selected sensors |
+| `touch_sensor_calibrate(calibrate_mask)` | Calibrate selected sensors |
+
+```python
+item = hand.get_single_touch_sensor_status(1)
+```
+
+---
+
+## LED / Buzzer / Vibration
+
+| Method | Description |
+| --- | --- |
+| `get_led_enabled()` / `set_led_enabled(enabled)` | LED switch |
+| `get_led_info()` / `set_led_info(led_info)` | Color, mode, brightness |
+| `get_buzzer_enabled()` / `set_buzzer_enabled(enabled)` | Buzzer switch |
+| `get_vibration_enabled()` / `set_vibration_enabled(enabled)` | Vibration motor switch |
+
+```python
+led = hand.LedInfo(hand.LedColor.RGB, hand.LedMode.Blink2Hz)
+hand.set_led_info(led)
+```
+
+---
+
+## Device Discovery
+
+### `scan_slave_ids(candidate_ids=None, *, timeout_ms=500) -> int | None`
+
+Search for a responding hand on the conversion board (default: try left and right hand ids). Does **not** change `hand_side` binding.
+
+```python
+device_id = hand.scan_slave_ids()
+print(device_id if device_id is not None else "no hand found")
+```
+
+---
+
+## Advanced: run_sdk and client
+
+### `run_sdk(fn, /, *args, **kwargs) -> T | None`
+
+Runs any `hand.client.<method>` on the SDK asyncio thread with automatic left/right routing and auto/failover handling.
+
+```python
+# Read (same as hand.get_finger_positions())
+pos = hand.run_sdk(hand.client.get_finger_positions)
+
+# Write
+hand.run_sdk(hand.client.set_finger_positions, [0, 500, 500, 500, 500, 500])
+
+# Unwrapped SDK methods, e.g.:
+# hand.run_sdk(hand.client.is_touch_hand)
+```
+
+Returns `None` on timeout or SDK error.
+
+### `hand.client`
+
+Direct access to **bc-stark-sdk** `DeviceContext`. Prefer wrapped driver methods; use `client` + `run_sdk` for APIs not exposed on the driver (DFU, action sequences, factory tools, etc.).
+
+> For full **`hand.client`** API details, see the official documentation: [Revo2 Python SDK](https://www.brainco-hz.com/docs/revolimb-hand/revo2/python_sdk.html)
+
+---
+
+## API Index
+
+All public methods on `revo2_touch` `Driver` (67):
+
+| Category | Methods |
+| --- | --- |
+| Routing | `set_hand_side`, `scan_slave_ids`, `run_sdk` |
+| Properties | `client`, `hand_side`, `slave_id` |
+| Device info | `get_device_info`, `get_device_sn`, `get_device_fw_version`, `get_sku_type`, `get_hand_type`, `get_button_event` |
+| Config | `get_auto_calibration_enabled`, `set_auto_calibration`, `calibrate_position`, `reset_default_settings`, `reboot` |
+| Position | `set_finger_position`, `set_finger_position_with_millis`, `set_finger_position_with_speed`, `set_finger_positions`, `set_finger_positions_and_durations`, `set_finger_positions_and_speeds`, `get_finger_positions` |
+| Speed | `set_finger_speed`, `set_finger_speeds`, `get_finger_speeds` |
+| Current | `set_finger_current`, `set_finger_currents`, `get_finger_currents` |
+| Status | `get_motor_status`, `get_motor_state` |
+| Settings | `get/set_finger_unit_mode`, `get_all_finger_settings`, `get/set_finger_settings`, min/max position/speed/current, protected currents, thumb aux lock |
+| Touch | `get_touch_sensor_*`, `touch_sensor_setup/reset/calibrate` |
+| Indicators | LED / buzzer / vibration get/set |
+
+**Type aliases on class:** `FingerId`, `FingerUnitMode`, `LedColor`, `LedInfo`, `LedMode`, `MotorSettings`
+
+---
+
+# Revo2 Touch 灵巧手 API 使用文档
+
+> 本文档描述 **Revo2 Touch** 电容触觉灵巧手的 Python API（基于 **bc-stark-sdk**）。
+
+> **提示：** 本 Driver 桥接了灵巧手官方 SDK。更多 SDK 能力与用法请参阅 [进阶：run_sdk 与 client](#进阶run_sdk-与-client)。
+
+## 目录
+
+- [切换到 English](#revo2-touch-api-documentation)
+- [概述](#概述)
+- [环境要求](#环境要求)
+- [快速开始](#快速开始)
+- [量程与手指顺序](#量程与手指顺序)
+- [创建实例并连接](#创建实例并连接-1)
+- [左右手路由](#左右手路由)
+- [Driver 上的 SDK 类型](#driver-上的-sdk-类型)
+- [设备信息](#设备信息)
+- [设备配置](#设备配置)
+- [手指运动控制](#手指运动控制)
+- [电机状态与参数](#电机状态与参数)
+- [电容触觉](#电容触觉)
+- [LED / 蜂鸣器 / 振动](#led--蜂鸣器--振动)
+- [设备发现](#设备发现)
+- [进阶：run_sdk 与 client](#进阶run_sdk-与-client)
+- [API 索引](#api-索引)
+
+---
+
+## 概述
+
+初始化 Revo2 Touch：
+
+```python
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+```
+
+> Driver 封装 **bc-stark-sdk**，经转换板与灵巧手通信。
+
+读接口失败时多返回 `None`；写接口经 `run_sdk` 在超时/错误时静默失败。
+
+---
+
+## 环境要求
+
+1. **硬件（必须）：** **Revo2 Touch 触觉手经 Agilex 转换板接入机械臂总线**
+2. **连接：** 与机械臂共用同一总线/通道，见 [CAN 模块手册](../../can_user.md)
+3. **依赖：** `pip install bc-stark-sdk`
+4. 必须 `robot.connect()` 启动读循环，才能正常收发灵巧手数据
+
+---
+
+## 快速开始
+
+**Nero 示例：**
+
+```python
+from pyAgxArm import AgxArmFactory, ArmModel, NeroFW, create_agx_arm_config
+
+cfg = create_agx_arm_config(robot=ArmModel.NERO, firmeware_version=NeroFW.V112, channel="can0")
+robot = AgxArmFactory.create_arm(cfg)
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+**Piper 示例**（末端 API 相同，仅机械臂配置不同）：
+
+```python
+from pyAgxArm import AgxArmFactory, ArmModel, PiperFW, create_agx_arm_config
+
+cfg = create_agx_arm_config(robot=ArmModel.PIPER, firmeware_version=PiperFW.V188, channel="can0")
+robot = AgxArmFactory.create_arm(cfg)
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+连接后通用用法：
+
+```python
+hand.set_hand_side("right")  # 可选；默认自动探测左右手
+
+info = hand.get_device_info()
+if info is not None:
+    print(info.description)
+
+item = hand.get_single_touch_sensor_status(1)
+if item is not None:
+    print(item.description)
+
+hand.set_finger_positions([500] * 6)
+
+robot.disconnect()
+```
+
+---
+
+## 量程与手指顺序
+
+**六指数组顺序：** 大拇指Flex、大拇指Aux、食指、中指、无名指、小指 — 使用 `hand.FingerId.*`。
+
+**统一量纲：**
+
+| 量 | 范围 | 说明 |
+| --- | --- | --- |
+| 位置 | 0 ~ 1000 | 0 张开，1000 闭合 |
+| 速度 | -1000 ~ +1000 | 正闭合，负张开 |
+| 电流 | -1000 ~ +1000 | 正闭合，负张开 |
+| 时长 | 1 ~ 2000 ms | Revo2 专用 API |
+
+---
+
+## 创建实例并连接
+
+```python
+hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+robot.connect()
+```
+
+常量：`REVO2_TOUCH = "revo2_touch"`。
+
+> 1. 每次连接会话只应调用一次 `init_effector`。  
+> 2. 建议在 `connect()` 前创建末端。  
+> 3. **前提：** 经 Agilex 转换板接入机械臂总线 + Revo2 Touch。
+
+---
+
+## 左右手路由
+
+| 属性 / 方法 | 说明 |
+| --- | --- |
+| `hand_side` | `"left"` / `"right"` / 未绑定时 `None` |
+| `slave_id` | 当前绑定的手设备 id，未绑定时 `None` |
+| `set_hand_side("left"\|"right")` | 固定左右手，不 failover |
+| `set_hand_side(None)` | 自动探测并绑定，失败时切换另一侧 |
+
+---
+
+## Driver 上的 SDK 类型
+
+| 属性 | 用途 |
+| --- | --- |
+| `FingerId` | 手指枚举 |
+| `FingerUnitMode` | 归一化 / 物理单位 |
+| `LedColor` / `LedMode` / `LedInfo` | LED |
+| `MotorSettings` | 单指电机参数 |
+
+---
+
+## 设备信息
+
+| 方法 | 说明 |
+| --- | --- |
+| `get_device_info()` | 设备信息（连接后建议先调一次） |
+| `get_device_sn()` | 序列号 |
+| `get_device_fw_version()` | 固件版本 |
+| `get_sku_type()` / `get_hand_type()` | SKU / 左右手类型 |
+| `get_button_event()` | 按键事件 |
+
+---
+
+## 设备配置
+
+| 方法 | 说明 |
+| --- | --- |
+| `get_auto_calibration_enabled()` / `set_auto_calibration()` | 自动校准开关 |
+| `calibrate_position()` | 手动位置校准 |
+| `reset_default_settings()` | 恢复出厂参数 |
+| `reboot()` | 重启 |
+
+---
+
+## 手指运动控制
+
+**单指：** `set_finger_position`、`set_finger_position_with_millis`、`set_finger_position_with_speed`、`set_finger_speed`、`set_finger_current`。
+
+**六指数组：** `set_finger_positions`、`set_finger_positions_and_durations`、`set_finger_positions_and_speeds`、`set_finger_speeds`、`set_finger_currents`。
+
+**读取：** `get_finger_positions`、`get_finger_speeds`、`get_finger_currents`。
+
+```python
+hand.set_finger_positions_and_speeds([1000] * 6, [300] * 6)
+```
+
+---
+
+## 电机状态与参数
+
+| 方法 | 说明 |
+| --- | --- |
+| `get_motor_status()` | 位置/速度/电流/状态汇总 |
+| `get_motor_state()` | 六指状态码 |
+| `get/set_finger_unit_mode` | 单位模式 |
+| `get_all_finger_settings` / `get/set_finger_settings` | 单指/全部参数 |
+| `get/set_finger_min/max_position` | 位置限位 |
+| `get/set_finger_max_speed` / `max_current` | 速度/电流上限 |
+| `get/set_finger_protected_current(s)` | 堵转保护电流 |
+| `get/set_thumb_aux_lock_current` | 拇指副指锁止电流 |
+
+---
+
+## 电容触觉
+
+Driver 封装的是 **电容触觉** 接口（不含 Force3D / 面阵压力；未封装能力可用 `run_sdk(hand.client.xxx)`）。
+
+| 方法 | 说明 |
+| --- | --- |
+| `get_touch_sensor_enabled()` | 已启用的指尖传感器 |
+| `get_touch_sensor_fw_versions()` | 各触觉传感器固件版本 |
+| `get_touch_sensor_raw_data()` | 原始数据 |
+| `get_touch_sensor_status()` | 五指状态列表 |
+| `get_single_touch_sensor_status(index)` | 单指，`index` 为 0–4 |
+| `touch_sensor_setup/reset/calibrate(mask)` | 启用 / 复位 / 校准指定传感器 |
+
+```python
+item = hand.get_single_touch_sensor_status(1)
+```
+
+---
+
+## LED / 蜂鸣器 / 振动
+
+| 方法 | 说明 |
+| --- | --- |
+| `get/set_led_enabled` | LED 开关 |
+| `get/set_led_info` | 颜色、模式、亮度 |
+| `get/set_buzzer_enabled` | 蜂鸣器 |
+| `get/set_vibration_enabled` | 振动马达 |
+
+---
+
+## 设备发现
+
+**`scan_slave_ids(candidate_ids=None, *, timeout_ms=500)`** — 在转换板上搜索有响应的灵巧手（默认尝试左右手），不改变当前 `hand_side` 绑定。
+
+---
+
+## 进阶：run_sdk 与 client
+
+**`run_sdk(fn, /, *args, **kwargs)`** — 在 SDK 线程执行 `hand.client` 任意方法，自动处理左右手路由与 failover。
+
+**`hand.client`** — 原始 `DeviceContext`；Driver 未封装的 SDK 能力（DFU、动作序列等）通过 `run_sdk` 调用。
+
+```python
+# 读（与 hand.get_finger_positions() 等价）
+pos = hand.run_sdk(hand.client.get_finger_positions)
+
+# 写
+hand.run_sdk(hand.client.set_finger_positions, [0, 500, 500, 500, 500, 500])
+```
+
+失败或超时时返回 `None`。
+
+> **`hand.client`** 的完整 API 说明请参阅官方文档：[Revo2 Python SDK](https://www.brainco-hz.com/docs/revolimb-hand/revo2/python_sdk.html)
+
+---
+
+## API 索引
+
+公开方法共 **67** 个，分类见 [English API Index](#api-index)。类属性：`FingerId`、`FingerUnitMode`、`LedColor`、`LedInfo`、`LedMode`、`MotorSettings`。

--- a/pyAgxArm/protocols/can_protocol/comms/__init__.py
+++ b/pyAgxArm/protocols/can_protocol/comms/__init__.py
@@ -1,11 +1,14 @@
 from .core.can_comm_base import CanCommBase
 from .comm_factory import CommsFactory, create_comm_config
 from .can_comm import CanComm, create_can_comm_config
+from .can20_canfd import Can20CanfdRx, CanFdMessage
 
 __all__ = [
     'CommsFactory',
     'CanCommBase',
     'CanComm',
     'create_can_comm_config',
-    'create_comm_config'
+    'create_comm_config',
+    'Can20CanfdRx',
+    'CanFdMessage',
 ]

--- a/pyAgxArm/protocols/can_protocol/comms/can20_canfd.py
+++ b/pyAgxArm/protocols/can_protocol/comms/can20_canfd.py
@@ -1,0 +1,407 @@
+"""
+CAN 2.0 transparent tunnel for CAN FD payloads (0x711 request / 0x712 response).
+
+This module implements **only the Agilex wrist conversion-board framing**:
+classic-CAN fragments (``55 AA`` header, sequence nibble, tail CRC16 over the
+CAN FD *data* field padded to ISO 11898-1 DLC lengths). It does **not**
+interpret ``arbitration_id`` or payload bytes.
+
+On TX, payloads are zero-padded to the next CAN FD DLC slot before
+fragmentation and CRC. On RX, the conversion board may omit trailing ``0x00``
+fill bytes in fragments, but the tail CRC is computed over the full padded
+slot padding is applied before CRC verification.
+
+Layering::
+
+    0x711/0x712 tunnel (this module)  →  logical CAN FD (id + data)
+                                         →  vendor SDK / driver
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Callable, Deque, List, Optional
+
+from can.message import Message
+
+DEFAULT_REQUEST_ID = 0x711
+DEFAULT_RESPONSE_ID = 0x712
+FIRST_FRAME_MARKER = bytes((0x55, 0xAA))
+CRC16_BYTEORDER = "little"
+PAYLOAD_CHUNK_SIZE = 7
+MAX_CANFD_DATA_LEN = 64
+# ISO 11898-1 CAN FD valid data-field byte counts (DLC mapping).
+CANFD_DLC_LENGTHS = (0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64)
+
+
+def _canfd_dlc_slot(length: int) -> int:
+    """Return the smallest CAN FD DLC byte count that fits *length*."""
+    if length < 0:
+        raise ValueError(f"length must be >= 0, got {length}")
+    if length > MAX_CANFD_DATA_LEN:
+        raise ValueError(
+            f"length must be <= {MAX_CANFD_DATA_LEN}, got {length}"
+        )
+    for slot in CANFD_DLC_LENGTHS:
+        if slot >= length:
+            return slot
+    return MAX_CANFD_DATA_LEN
+
+
+def _pad_to_canfd_dlc(data: bytes) -> bytes:
+    """Pad *data* with trailing ``0x00`` bytes to the next CAN FD DLC slot."""
+    slot = _canfd_dlc_slot(len(data))
+    if len(data) == slot:
+        return data
+    return data + bytes(slot - len(data))
+
+
+def _crc16_ccitt_false(data: bytes) -> int:
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc
+
+
+def _encode_sequence_byte(frame_group: int, sequence: int) -> int:
+    if not 1 <= frame_group <= 15:
+        raise ValueError("frame_group must be in [1, 15]")
+    if not 1 <= sequence <= frame_group:
+        raise ValueError("sequence must be in [1, frame_group]")
+    return ((frame_group << 4) | sequence) & 0xFF
+
+
+class CanFdMessage:
+    """
+    One logical CAN FD frame carried over classic CAN 2.0 tunnel fragments.
+
+    Parameters
+    ----------
+    arbitration_id
+        CAN FD frame id (placed in the first fragment ``data[3:7]``).
+    data
+        CAN FD payload (0..64 bytes). Total frame count and tail CRC are derived
+        automatically on construction.
+    tunnel_id
+        Classic CAN arbitration id used on the host bus (default ``0x711``).
+    """
+
+    def __init__(
+        self,
+        arbitration_id: int,
+        data: bytes = b"",
+        *,
+        tunnel_id: int = DEFAULT_REQUEST_ID,
+    ) -> None:
+        if not 0 <= arbitration_id <= 0xFFFFFFFF:
+            raise ValueError("arbitration_id must fit in 32 bits")
+        payload = bytes(data)
+        if len(payload) > MAX_CANFD_DATA_LEN:
+            raise ValueError(
+                f"CAN FD data length must be <= {MAX_CANFD_DATA_LEN}, got {len(payload)}"
+            )
+
+        self.arbitration_id = arbitration_id
+        self.data = payload
+        self._tunnel_id = tunnel_id
+        self._fragments = self._build_fragments()
+
+    @property
+    def msgs(self) -> List[Message]:
+        """Classic-CAN fragments ready to send (``is_extended_id`` is always False)."""
+        return [
+            Message(
+                arbitration_id=self._tunnel_id,
+                is_extended_id=False,
+                data=fragment,
+            )
+            for fragment in self._fragments
+        ]
+
+    def _build_fragments(self) -> List[bytes]:
+        framed_data = _pad_to_canfd_dlc(self.data)
+        chunks = [
+            framed_data[i : i + PAYLOAD_CHUNK_SIZE]
+            for i in range(0, len(framed_data), PAYLOAD_CHUNK_SIZE)
+        ]
+        frame_group = 1 + len(chunks) + 1
+        if frame_group > 15:
+            raise ValueError(
+                f"too many fragments: {frame_group}, protocol nibble limit is 15"
+            )
+
+        id_bytes = self.arbitration_id.to_bytes(4, "big")
+        frames: List[bytes] = [
+            bytes(
+                (
+                    _encode_sequence_byte(frame_group, 1),
+                    FIRST_FRAME_MARKER[0],
+                    FIRST_FRAME_MARKER[1],
+                )
+            )
+            + id_bytes
+        ]
+        for index, chunk in enumerate(chunks, start=2):
+            frames.append(
+                bytes((_encode_sequence_byte(frame_group, index),)) + chunk
+            )
+
+        crc_bytes = _crc16_ccitt_false(framed_data).to_bytes(2, CRC16_BYTEORDER)
+        frames.append(
+            bytes((_encode_sequence_byte(frame_group, frame_group),)) + crc_bytes
+        )
+        return frames
+
+
+class Can20CanfdRx:
+    """
+    Collect and reassemble one tunneled CAN FD reply from 0x712 fragments.
+
+    Intended for use with the arm read-loop callback (``can_comm.recv`` →
+    ``_trigger_callback``): register :meth:`feed` on the callback path, send
+    request fragments via ``comm.send`` yourself, then :meth:`wait`.
+    """
+
+    class _Reassembler:
+        """Incrementally reassemble one tunneled transaction from tunnel fragments."""
+
+        def __init__(self) -> None:
+            self.reset()
+
+        def reset(self) -> None:
+            self._frame_group: Optional[int] = None
+            self._arbitration_id: Optional[int] = None
+            self._next_sequence: Optional[int] = None
+            self._payload = bytearray()
+
+        def feed(self, _can_id: int, data: bytes) -> Optional[CanFdMessage]:
+            if not data:
+                return None
+
+            encoded = data[0]
+            encoded_group = encoded >> 4
+            sequence = encoded & 0x0F
+            if encoded_group < 1 or sequence == 0 or sequence > encoded_group:
+                return None
+
+            if sequence == 1:
+                if len(data) != 7 or data[1:3] != FIRST_FRAME_MARKER:
+                    return None
+
+                self._frame_group = encoded_group
+                self._arbitration_id = int.from_bytes(data[3:7], "big")
+                self._payload.clear()
+                self._next_sequence = 2
+                return None
+
+            if (
+                self._frame_group is None
+                or encoded_group != self._frame_group
+                or sequence != self._next_sequence
+                or self._arbitration_id is None
+            ):
+                return None
+
+            if sequence == self._frame_group:
+                body = bytes(self._payload)
+                raw_crc = data[1:3]
+                if len(raw_crc) == 2:
+                    expected_crc = int.from_bytes(raw_crc, CRC16_BYTEORDER)
+                    actual_crc = _crc16_ccitt_false(_pad_to_canfd_dlc(body))
+                    if expected_crc != actual_crc:
+                        print(
+                            "[WARNING] tunnel CRC mismatch: "
+                            f"received=0x{expected_crc:04X}, "
+                            f"calculated=0x{actual_crc:04X}"
+                        )
+                return CanFdMessage(self._arbitration_id, body)
+
+            self._payload.extend(data[1:])
+            self._next_sequence = (self._next_sequence or 0) + 1
+            return None
+
+    def __init__(self, response_id: int = DEFAULT_RESPONSE_ID) -> None:
+        self.response_id = response_id
+        self._lock = threading.Lock()
+        self._reassembler = self._Reassembler()
+        self._pending: Optional[CanFdMessage] = None
+        self._spare: Deque[CanFdMessage] = deque()
+        self._ready = threading.Event()
+        self._error: Optional[BaseException] = None
+
+    def reset(self) -> None:
+        with self._lock:
+            self._reassembler.reset()
+            self._pending = None
+            self._spare.clear()
+            self._error = None
+            self._ready.clear()
+
+    def feed(self, message: Message) -> None:
+        if message.arbitration_id != self.response_id:
+            return
+
+        data = bytes(message.data)
+        if not data:
+            return
+
+        with self._lock:
+            sequence = data[0] & 0x0F
+            if sequence == 1:
+                if self._pending is not None:
+                    self._spare.append(self._pending)
+                    self._pending = None
+                self._reassembler.reset()
+                self._error = None
+                self._ready.clear()
+            elif self._ready.is_set():
+                return
+
+            try:
+                result = self._reassembler.feed(
+                    message.arbitration_id, data
+                )
+                if result is not None:
+                    self._pending = CanFdMessage(
+                        result.arbitration_id,
+                        result.data,
+                        tunnel_id=self.response_id,
+                    )
+                    self._ready.set()
+            except BaseException as exc:
+                self._error = exc
+                self._ready.set()
+
+    def wait(self, timeout: Optional[float] = None) -> Optional[CanFdMessage]:
+        """Block until one complete reply arrives via :meth:`feed`."""
+        return self.wait_matching(timeout, lambda _msg: True)
+
+    def wait_matching(
+        self,
+        timeout: Optional[float],
+        predicate: Callable[[CanFdMessage], bool],
+    ) -> Optional[CanFdMessage]:
+        """Block until a complete reply satisfying *predicate* arrives."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+
+        while True:
+            with self._lock:
+                for index, msg in enumerate(self._spare):
+                    if predicate(msg):
+                        del self._spare[index]
+                        return msg
+
+            complete = self._take_complete()
+            if complete is not None:
+                if predicate(complete):
+                    return complete
+                with self._lock:
+                    self._spare.append(complete)
+                continue
+
+            if deadline is not None and time.monotonic() >= deadline:
+                return None
+
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                return None
+
+            wait_s = remaining if remaining is not None else 0.01
+            self._ready.wait(timeout=min(wait_s, 0.01) if wait_s else 0.01)
+
+    def _take_complete(self) -> Optional[CanFdMessage]:
+        with self._lock:
+            if self._error is not None:
+                raise self._error
+            if self._pending is None:
+                return None
+            msg = self._pending
+            self._pending = None
+            self._ready.clear()
+            self._reassembler.reset()
+            return msg
+
+
+if __name__ == "__main__":
+    print("can20_canfd demos (no hardware)")
+
+    # ------------------------------------------------------------------
+    # Example 1: fragment a short CAN FD message onto classic CAN 0x711
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Example 1: short payload (single data frame)")
+    short = CanFdMessage(0x007E0806, bytes.fromhex("7e0400000006"))
+    print(f"  CAN FD id = 0x{short.arbitration_id:08X}")
+    print(f"  payload   = {short.data.hex()} ({len(short.data)} bytes)")
+    print(f"  fragments on 0x{short.msgs[0].arbitration_id:03X} x {len(short.msgs)}:")
+    for index, msg in enumerate(short.msgs, start=1):
+        print(f"    [{index}] data = {bytes(msg.data).hex()}")
+
+    # ------------------------------------------------------------------
+    # Example 2: fragment a long payload into multiple data frames
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Example 2: long payload (multiple data frames)")
+    long_payload = b"Revo2 touch tunnel demo: " + bytes(range(16))
+    long_msg = CanFdMessage(0x007E081F, long_payload)
+    print(f"  CAN FD id = 0x{long_msg.arbitration_id:08X}")
+    print(f"  payload   = {long_msg.data.hex()} ({len(long_msg.data)} bytes)")
+    print(f"  fragments on 0x{long_msg.msgs[0].arbitration_id:03X} x {len(long_msg.msgs)}:")
+    for index, msg in enumerate(long_msg.msgs, start=1):
+        print(f"    [{index}] data = {bytes(msg.data).hex()}")
+
+    # ------------------------------------------------------------------
+    # Example 3: reassemble a synthetic 0x712 reply (feed + wait)
+    # Tunnel layer returns full (id, data); id semantics are vendor-specific.
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Example 3: rx roundtrip via feed() + wait()")
+    payload = bytes.fromhex("7e040000000c010203040506")  # 12 bytes
+    logical = CanFdMessage(0x007E0806, payload)  # id low byte need not match len
+    response = CanFdMessage(
+        logical.arbitration_id,
+        logical.data,
+        tunnel_id=DEFAULT_RESPONSE_ID,
+    )
+    rx = Can20CanfdRx()
+    rx.reset()
+    for fragment in response.msgs:
+        rx.feed(fragment)
+    got = rx.wait(timeout=1.0)
+    assert got is not None
+    assert got.arbitration_id == logical.arbitration_id
+    assert got.data == logical.data
+    print(f"  reassembled id      = 0x{got.arbitration_id:08X}")
+    print(f"  reassembled payload = {got.data.hex()}")
+
+    # ------------------------------------------------------------------
+    # Example 4: async callback delivery while wait() blocks
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Example 4: rx async feed (read-loop callback simulation)")
+    payload = b"\x01\x02\x03\x04\x05\x06\x07\x08\x09"
+    arb_id = 0x007F0A0B  # opaque to tunnel; only framing + tail CRC matter
+    rx = Can20CanfdRx()
+    rx.reset()
+
+    def _late_reply() -> None:
+        time.sleep(0.05)
+        late_response = CanFdMessage(arb_id, payload, tunnel_id=DEFAULT_RESPONSE_ID)
+        for fragment in late_response.msgs:
+            rx.feed(fragment)
+
+    threading.Thread(target=_late_reply, daemon=True).start()
+    t0 = time.monotonic()
+    got = rx.wait(timeout=1.0)
+    elapsed_ms = (time.monotonic() - t0) * 1000.0
+    assert got is not None
+    print(f"  waited {elapsed_ms:.1f} ms for callback delivery")
+    print(f"  reassembled payload = {got.data.hex()}")
+
+    print("\n" + "=" * 60)
+    print("All demos OK.")

--- a/pyAgxArm/protocols/can_protocol/drivers/core/arm_driver_abstract.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/core/arm_driver_abstract.py
@@ -24,6 +24,7 @@ from .....utiles.tf import (
 if TYPE_CHECKING:
     from ..effector.agx_gripper import AgxGripperDriverDefault
     from ..effector.revo2 import Revo2DriverDefault
+    from ..effector.revo2_touch import Revo2TouchDriverDefault
 
 
 class ArmDriverAbstract(ArmDriverInterface):
@@ -148,6 +149,14 @@ class ArmDriverAbstract(ArmDriverInterface):
         """
         ...
 
+    @overload
+    def init_effector(
+        self, effector: Literal["revo2_touch"]
+    ) -> "Revo2TouchDriverDefault":
+        """revo2 touch-hand end-effector driver.
+        """
+        ...
+
     def init_effector(self, effector: str):
         """Initialize end-effector driver exactly once and return the driver instance.
         """
@@ -170,6 +179,12 @@ class ArmDriverAbstract(ArmDriverInterface):
             from ..effector.revo2 import Revo2DriverDefault
 
             self._effector = Revo2DriverDefault(self._config, self.get_context())
+            return self._effector
+
+        if effector_kind == self.OPTIONS.EFFECTOR.REVO2_TOUCH:
+            from ..effector.revo2_touch import Revo2TouchDriverDefault
+
+            self._effector = Revo2TouchDriverDefault(self._config, self.get_context())
             return self._effector
 
         raise ValueError(f"Unsupported effector kind: {effector}")

--- a/pyAgxArm/protocols/can_protocol/drivers/core/protocol_parser_abstract.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/core/protocol_parser_abstract.py
@@ -15,6 +15,7 @@ class DriverAPIOptions:
 
         AGX_GRIPPER: Final[Literal["agx_gripper"]] = "agx_gripper"
         REVO2: Final[Literal["revo2"]] = "revo2"
+        REVO2_TOUCH: Final[Literal["revo2_touch"]] = "revo2_touch"
 
 class DriverAPIProtoAdapter:
     pass

--- a/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/__init__.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/__init__.py
@@ -1,0 +1,3 @@
+from .default.driver import Driver as Revo2TouchDriverDefault
+
+__all__ = ["Revo2TouchDriverDefault"]

--- a/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/__init__.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/__init__.py
@@ -1,0 +1,3 @@
+from .driver import Driver
+
+__all__ = ["Driver"]

--- a/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/driver.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/driver.py
@@ -1,0 +1,1261 @@
+"""
+Revo2 touch-hand driver: wrist CAN tunnel + bc-stark-sdk + left/right routing.
+"""
+
+import asyncio
+import inspect
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Concatenate,
+    List,
+    Literal,
+    Optional,
+    ParamSpec,
+    Sequence,
+    TypeVar,
+    Union,
+)
+
+from ....core.driver_context import DriverContext
+from .libstark_bridge import LibStarkBridge
+
+if TYPE_CHECKING:
+    from bc_stark_sdk.main_mod import (
+        ButtonPressEvent,
+        DeviceContext,
+        DeviceInfo,
+        FingerId,
+        FingerUnitMode,
+        HandType,
+        LedColor,
+        LedInfo,
+        LedMode,
+        MotorSettings,
+        MotorStatusData,
+        SkuType,
+        TouchFingerItem,
+        TouchRawData,
+    )
+else:
+    try:
+        from bc_stark_sdk.main_mod import (
+            ButtonPressEvent,
+            DeviceContext,
+            DeviceInfo,
+            FingerId,
+            FingerUnitMode,
+            HandType,
+            LedColor,
+            LedInfo,
+            LedMode,
+            MotorSettings,
+            MotorStatusData,
+            SkuType,
+            TouchFingerItem,
+            TouchRawData,
+        )
+    except ImportError:  # pragma: no cover
+        ButtonPressEvent = object  # type: ignore[misc, assignment]
+        DeviceContext = object  # type: ignore[misc, assignment]
+        DeviceInfo = object  # type: ignore[misc, assignment]
+        FingerId = object  # type: ignore[misc, assignment]
+        FingerUnitMode = object  # type: ignore[misc, assignment]
+        HandType = object  # type: ignore[misc, assignment]
+        LedColor = object  # type: ignore[misc, assignment]
+        LedInfo = object  # type: ignore[misc, assignment]
+        LedMode = object  # type: ignore[misc, assignment]
+        MotorSettings = object  # type: ignore[misc, assignment]
+        MotorStatusData = object  # type: ignore[misc, assignment]
+        SkuType = object  # type: ignore[misc, assignment]
+        TouchFingerItem = object  # type: ignore[misc, assignment]
+        TouchRawData = object  # type: ignore[misc, assignment]
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+HandSide = Literal["left", "right"]
+
+_DEVICE_ID_BY_HAND = {
+    "left": 0x7E,
+    "right": 0x7F,
+}
+
+
+def _normalize_hand_side(value: object) -> HandSide:
+    if not isinstance(value, str):
+        raise TypeError("hand_side must be a string: 'left' or 'right'")
+    key = value.strip().lower()
+    if key in _DEVICE_ID_BY_HAND:
+        return key  # type: ignore[return-value]
+    raise ValueError("hand_side must be exactly 'left' or 'right'")
+
+
+def _device_id_for_hand(hand: HandSide) -> int:
+    return _DEVICE_ID_BY_HAND[hand]
+
+
+def _hand_for_device_id(device_id: int) -> HandSide:
+    for hand, dev_id in _DEVICE_ID_BY_HAND.items():
+        if dev_id == device_id:
+            return hand  # type: ignore[return-value]
+    raise ValueError(f"unknown touch-hand device id: 0x{device_id:02X}")
+
+
+def _other_hand_side(hand: HandSide) -> HandSide:
+    return "right" if hand == "left" else "left"
+
+
+async def _invoke_sdk(
+    fn: Callable[..., Any],
+    slave_id: int,
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """
+    bc-stark-sdk methods may return synchronously (e.g. bool capability probes)
+    or a Future that must be awaited on the SDK asyncio loop.
+    """
+    result = fn(slave_id, *args, **kwargs)
+    if inspect.iscoroutine(result) or asyncio.isfuture(result):
+        return await result
+    if hasattr(result, "__await__"):
+        return await result
+    return result
+
+
+class Driver:
+    """
+    Transport and hand-side routing; wraps bc-stark-sdk ``DeviceContext`` APIs.
+
+    Unwrapped SDK helpers may still be invoked via :meth:`run_sdk` or :attr:`client`.
+
+    Quick start (``hand`` is this driver)::
+
+        from pyAgxArm import AgxArmFactory
+
+        robot = AgxArmFactory.create_arm(cfg)
+        robot.connect()
+        hand = robot.init_effector(robot.OPTIONS.EFFECTOR.REVO2_TOUCH)
+        hand.set_hand_side("right")  # optional; default auto-probes 0x7E/0x7F
+        hand.set_finger_position(hand.FingerId.Index, 500)
+        info = hand.get_device_info()
+    """
+
+    # bc-stark-sdk types used by Driver method parameters (avoid separate import).
+    FingerId = FingerId
+    FingerUnitMode = FingerUnitMode
+    LedColor = LedColor
+    LedInfo = LedInfo
+    LedMode = LedMode
+    MotorSettings = MotorSettings
+
+    def __init__(self, config: dict, ctx: DriverContext):
+        del config
+        self._bridge = LibStarkBridge(ctx)
+        self._bridge.start()
+        self._auto_mode = True
+        self._active_side: Optional[HandSide] = None
+
+    @property
+    def client(self) -> DeviceContext:
+        """Official bc-stark-sdk ``DeviceContext`` (async methods).
+
+        Example::
+
+            ctx = hand.client  # raw bc-stark-sdk DeviceContext
+        """
+        return self._bridge.client
+
+    @property
+    def hand_side(self) -> Optional[str]:
+        """``"left"``, ``"right"``, or ``None`` when auto mode is not yet bound.
+
+        Example::
+
+            side = hand.hand_side
+        """
+        return self._active_side
+
+    @property
+    def slave_id(self) -> Optional[int]:
+        """Bound Modbus slave id (``0x7E`` / ``0x7F``), or ``None`` if not yet known.
+
+        Example::
+
+            sid = hand.slave_id  # e.g. 127 (0x7F)
+        """
+        if self._active_side is None:
+            return None
+        return _device_id_for_hand(self._active_side)
+
+    def set_hand_side(self, side: Optional[Union[str, HandSide]] = None) -> None:
+        """Select left/right routing or revert to auto probe/failover.
+
+        Args:
+            side: ``"left"``, ``"right"``, or ``None`` for auto mode (default).
+
+        Example::
+
+            hand.set_hand_side("right")  # or None for auto-probe
+        """
+        if side is None:
+            self._auto_mode = True
+            self._active_side = None
+            return
+        hand = _normalize_hand_side(side)
+        self._auto_mode = False
+        self._active_side = hand
+
+    # --- device info ---
+
+    def get_device_info(self) -> Optional[DeviceInfo]:
+        """Get device information (serial number, firmware version, hardware type)
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Important: Call once after connect; SDK caches hardware type for capability routing.
+
+        Returns:
+            DeviceInfo: serial_number, firmware_version, hardware_type, hand_type, etc.
+
+        Example::
+
+            info = hand.get_device_info()
+        """
+        return self.run_sdk(self.client.get_device_info)
+
+    def get_device_sn(self) -> Optional[str]:
+        """Get device serial number.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            str: Device serial number
+
+        Example::
+
+            sn = hand.get_device_sn()  # e.g. "BCXTR1354J2500009"
+        """
+        return self.run_sdk(self.client.get_device_sn)
+
+    def get_device_fw_version(self) -> Optional[str]:
+        """Get device firmware version.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            str: Firmware version string
+
+        Example::
+
+            ver = hand.get_device_fw_version()  # e.g. "1.0.16.U"
+        """
+        return self.run_sdk(self.client.get_device_fw_version)
+
+    def get_sku_type(self) -> Optional[SkuType]:
+        """Get device SKU type (hand side: left/right).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            SkuType: Device SKU type
+
+        Example::
+
+            sku = hand.get_sku_type()
+        """
+        return self.run_sdk(self.client.get_sku_type)
+
+    def get_hand_type(self) -> Optional[HandType]:
+        """Get device hand type (simplified left/right).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            HandType enum (Left = 0, Right = 1)
+
+        Example::
+
+            ht = hand.get_hand_type()
+        """
+        return self.run_sdk(self.client.get_hand_type)
+
+    def get_button_event(self) -> Optional[ButtonPressEvent]:
+        """Get button press event.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            ButtonPressEvent: Button press event data
+
+        Example::
+
+            evt = hand.get_button_event()
+        """
+        return self.run_sdk(self.client.get_button_event)
+
+    # --- device config ---
+
+    def get_auto_calibration_enabled(self) -> Optional[bool]:
+        """Check if auto calibration is enabled.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            bool: True if auto calibration is enabled
+
+        Example::
+
+            enabled = hand.get_auto_calibration_enabled()
+        """
+        return self.run_sdk(self.client.get_auto_calibration_enabled)
+
+    def set_auto_calibration(self, enabled: bool) -> None:
+        """Enable or disable auto calibration.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            enabled: True to enable, False to disable
+
+        Example::
+
+            hand.set_auto_calibration(True)
+        """
+        self.run_sdk(self.client.set_auto_calibration, enabled)
+
+    def calibrate_position(self) -> None:
+        """Trigger manual position calibration.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Example::
+
+            hand.calibrate_position()
+        """
+        self.run_sdk(self.client.calibrate_position)
+
+    def reset_default_settings(self) -> None:
+        """Reset all settings to factory defaults.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Example::
+
+            hand.reset_default_settings()
+        """
+        self.run_sdk(self.client.reset_default_settings)
+
+    def reboot(self) -> None:
+        """Reboot the device.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Example::
+
+            hand.reboot()
+        """
+        self.run_sdk(self.client.reboot)
+
+    # --- motor control: position ---
+
+    def set_finger_position(self, finger_id: FingerId, position: int) -> None:
+        """Set finger position
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            position: Position value, unified range **0~1000** (all devices, all protocols)
+            0 = fully open, 1000 = fully closed
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_position(hand.FingerId.Index, 500)
+        """
+        self.run_sdk(self.client.set_finger_position, finger_id, position)
+
+    def set_finger_position_with_millis(
+        self, finger_id: FingerId, position: int, milliseconds: int
+    ) -> None:
+        """Set finger position with duration
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            position: Position value, unified range **0~1000** (all protocols)
+            milliseconds: Duration in milliseconds (1~2000ms)
+
+        Note: Only supported on Revo2 devices.
+
+        Example::
+
+            hand.set_finger_position_with_millis(hand.FingerId.Index, 500, 800)
+        """
+        self.run_sdk(
+            self.client.set_finger_position_with_millis,
+            finger_id,
+            position,
+            milliseconds,
+        )
+
+    def set_finger_position_with_speed(
+        self, finger_id: FingerId, position: int, speed: int
+    ) -> None:
+        """Set finger position with speed
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            position: Position value, unified range **0~1000** (all protocols)
+            speed: Speed value (1~1000)
+
+        Note: Only supported on Revo2 devices.
+
+        Example::
+
+            hand.set_finger_position_with_speed(hand.FingerId.Index, 500, 200)
+        """
+        self.run_sdk(
+            self.client.set_finger_position_with_speed,
+            finger_id,
+            position,
+            speed,
+        )
+
+    def set_finger_positions(self, positions: Sequence[int]) -> None:
+        """Set multiple finger positions
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            positions: Position array (length 6), unified range **0~1000** (all devices, all protocols)
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_positions([0, 500, 500, 500, 500, 500])
+        """
+        self.run_sdk(self.client.set_finger_positions, list(positions))
+
+    def set_finger_positions_and_durations(
+        self, positions: Sequence[int], durations: Sequence[int]
+    ) -> None:
+        """Set multiple finger positions with durations (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            positions: Position array (length 6), unified range 0~1000
+            durations: Duration array (length 6), in milliseconds (1~2000ms)
+
+        Example::
+
+            hand.set_finger_positions_and_durations([500] * 6, [1000] * 6)
+        """
+        self.run_sdk(
+            self.client.set_finger_positions_and_durations,
+            list(positions),
+            list(durations),
+        )
+
+    def set_finger_positions_and_speeds(
+        self, positions: Sequence[int], speeds: Sequence[int]
+    ) -> None:
+        """Set multiple finger positions with speeds (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            positions: Position array (length 6), unified range 0~1000
+            speeds: Speed array (length 6), range 1~1000
+
+        Example::
+
+            hand.set_finger_positions_and_speeds([500] * 6, [200] * 6)
+        """
+        self.run_sdk(
+            self.client.set_finger_positions_and_speeds,
+            list(positions),
+            list(speeds),
+        )
+
+    def get_finger_positions(self) -> Optional[List[int]]:
+        """Get finger positions
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            Position array (length 6), unified range **0~1000** (all devices, all protocols)
+
+        Note: SDK automatically converts internal values to unified external range.
+
+        Example::
+
+            pos = hand.get_finger_positions()
+        """
+        return self.run_sdk(self.client.get_finger_positions)
+
+    # --- motor control: speed ---
+
+    def set_finger_speed(self, finger_id: FingerId, speed: int) -> None:
+        """Set finger speed
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            speed: Speed value, unified range **-1000~+1000** (all devices, all protocols)
+            Positive = close, Negative = open, 0 = stop
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_speed(hand.FingerId.Index, 300)
+        """
+        self.run_sdk(self.client.set_finger_speed, finger_id, speed)
+
+    def set_finger_speeds(self, speeds: Sequence[int]) -> None:
+        """Set multiple finger speeds
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            speeds: Speed array (length 6), unified range **-1000~+1000** (all devices, all protocols)
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_speeds([0, 300, 0, 0, 0, 0])
+        """
+        self.run_sdk(self.client.set_finger_speeds, list(speeds))
+
+    def get_finger_speeds(self) -> Optional[List[int]]:
+        """Get finger speeds
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            Speed array (length 6), unified range **-1000~+1000** (all devices, all protocols)
+
+        Note: SDK automatically converts internal values to unified external range.
+
+        Example::
+
+            speeds = hand.get_finger_speeds()
+        """
+        return self.run_sdk(self.client.get_finger_speeds)
+
+    # --- motor control: current ---
+
+    def set_finger_current(self, finger_id: FingerId, current: int) -> None:
+        """Set finger current
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            current: Current value, unified range **-1000~+1000** (all devices, all protocols)
+            Positive = close, Negative = open
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_current(hand.FingerId.Index, 200)
+        """
+        self.run_sdk(self.client.set_finger_current, finger_id, current)
+
+    def set_finger_currents(self, currents: Sequence[int]) -> None:
+        """Set multiple finger currents
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            currents: Current array (length 6), unified range **-1000~+1000** (all devices, all protocols)
+
+        Note: SDK automatically converts to internal range based on device type and protocol.
+
+        Example::
+
+            hand.set_finger_currents([0, 200, 0, 0, 0, 0])
+        """
+        self.run_sdk(self.client.set_finger_currents, list(currents))
+
+    def get_finger_currents(self) -> Optional[List[int]]:
+        """Get finger currents
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            Current array (length 6), unified range **-1000~+1000** (all devices, all protocols)
+
+        Note: SDK automatically converts internal values to unified external range.
+
+        Example::
+
+            currents = hand.get_finger_currents()
+        """
+        return self.run_sdk(self.client.get_finger_currents)
+
+    # --- motor status ---
+
+    def get_motor_status(self) -> Optional[MotorStatusData]:
+        """Get motor status
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            MotorStatusData containing: - positions: Position array, unified range **0~1000** (all devices, all protocols) - speeds: Speed array, unified range **-1000~+1000** (all devices, all protocols) - currents: Current array, unified range **-1000~+1000** (all devices, all protocols) - states: Motor state array
+
+        Note: SDK automatically converts internal values to unified external range.
+
+        Example::
+
+            status = hand.get_motor_status()
+        """
+        return self.run_sdk(self.client.get_motor_status)
+
+    def get_motor_state(self) -> Optional[List[int]]:
+        """Get motor state (running, idle, stalled, etc.).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            list[int]: Motor state code array (length 6).
+
+        Example::
+
+            states = hand.get_motor_state()
+        """
+        return self.run_sdk(self.client.get_motor_state)
+
+    # --- motor settings ---
+
+    def get_finger_unit_mode(self) -> Optional[FingerUnitMode]:
+        """Get finger unit mode (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            FingerUnitMode: Current finger unit mode
+
+        Example::
+
+            mode = hand.get_finger_unit_mode()
+        """
+        return self.run_sdk(self.client.get_finger_unit_mode)
+
+    def set_finger_unit_mode(self, mode: FingerUnitMode) -> None:
+        """Set finger unit mode (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            mode: FingerUnitMode (FiveFingers or SixFingers)
+
+        Example::
+
+            hand.set_finger_unit_mode(hand.FingerUnitMode.Normalized)
+        """
+        self.run_sdk(self.client.set_finger_unit_mode, mode)
+
+    def get_all_finger_settings(self) -> Optional[List[MotorSettings]]:
+        """Get motor settings for all fingers (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            list: MotorSettings for all fingers
+
+        Example::
+
+            settings = hand.get_all_finger_settings()
+        """
+        return self.run_sdk(self.client.get_all_finger_settings)
+
+    def get_finger_settings(self, finger_id: FingerId) -> Optional[MotorSettings]:
+        """Get motor settings for a single finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            MotorSettings: Settings for the specified finger
+
+        Example::
+
+            cfg = hand.get_finger_settings(hand.FingerId.Thumb)
+        """
+        return self.run_sdk(self.client.get_finger_settings, finger_id)
+
+    def set_finger_settings(self, finger_id: FingerId, settings: MotorSettings) -> None:
+        """Set motor settings for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            settings: MotorSettings object
+
+        Example::
+
+            cfg = hand.get_finger_settings(hand.FingerId.Thumb)
+            hand.set_finger_settings(hand.FingerId.Thumb, cfg)
+        """
+        self.run_sdk(self.client.set_finger_settings, finger_id, settings)
+
+    def get_finger_min_position(self, finger_id: FingerId) -> Optional[int]:
+        """Get minimum position limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            int: Minimum position value
+
+        Example::
+
+            lo = hand.get_finger_min_position(hand.FingerId.Index)
+        """
+        return self.run_sdk(self.client.get_finger_min_position, finger_id)
+
+    def set_finger_min_position(self, finger_id: FingerId, position: int) -> None:
+        """Set minimum position limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            position: Minimum position value
+
+        Example::
+
+            hand.set_finger_min_position(hand.FingerId.Index, 0)
+        """
+        self.run_sdk(self.client.set_finger_min_position, finger_id, position)
+
+    def get_finger_max_position(self, finger_id: FingerId) -> Optional[int]:
+        """Get maximum position limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            int: Maximum position value
+
+        Example::
+
+            hi = hand.get_finger_max_position(hand.FingerId.Index)
+        """
+        return self.run_sdk(self.client.get_finger_max_position, finger_id)
+
+    def set_finger_max_position(self, finger_id: FingerId, position: int) -> None:
+        """Set maximum position limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            position: Maximum position value
+
+        Example::
+
+            hand.set_finger_max_position(hand.FingerId.Index, 1000)
+        """
+        self.run_sdk(self.client.set_finger_max_position, finger_id, position)
+
+    def get_finger_max_speed(self, finger_id: FingerId) -> Optional[int]:
+        """Get maximum speed limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            int: Maximum speed value
+
+        Example::
+
+            max_spd = hand.get_finger_max_speed(hand.FingerId.Index)
+        """
+        return self.run_sdk(self.client.get_finger_max_speed, finger_id)
+
+    def set_finger_max_speed(self, finger_id: FingerId, speed: int) -> None:
+        """Set maximum speed limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            speed: Maximum speed value
+
+        Example::
+
+            hand.set_finger_max_speed(hand.FingerId.Index, 500)
+        """
+        self.run_sdk(self.client.set_finger_max_speed, finger_id, speed)
+
+    def get_finger_max_current(self, finger_id: FingerId) -> Optional[int]:
+        """Get maximum current limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            int: Maximum current value
+
+        Example::
+
+            max_cur = hand.get_finger_max_current(hand.FingerId.Index)
+        """
+        return self.run_sdk(self.client.get_finger_max_current, finger_id)
+
+    def set_finger_max_current(self, finger_id: FingerId, current: int) -> None:
+        """Set maximum current limit for a finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            current: Maximum current value
+
+        Example::
+
+            hand.set_finger_max_current(hand.FingerId.Index, 800)
+        """
+        self.run_sdk(self.client.set_finger_max_current, finger_id, current)
+
+    def get_finger_protected_current(self, finger_id: FingerId) -> Optional[int]:
+        """Get protected current for a single finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+
+        Returns:
+            int: Protected current value
+
+        Example::
+
+            pc = hand.get_finger_protected_current(hand.FingerId.Index)
+        """
+        return self.run_sdk(self.client.get_finger_protected_current, finger_id)
+
+    def set_finger_protected_current(self, finger_id: FingerId, current: int) -> None:
+        """Set protected current for a single finger (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            finger_id: Finger ID
+            current: Protected current value
+
+        Example::
+
+            hand.set_finger_protected_current(hand.FingerId.Index, 500)
+        """
+        self.run_sdk(self.client.set_finger_protected_current, finger_id, current)
+
+    def get_finger_protected_currents(self) -> Optional[List[int]]:
+        """Get protected currents for all fingers (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            list: Protected current array (length 6)
+
+        Example::
+
+            pcs = hand.get_finger_protected_currents()
+        """
+        return self.run_sdk(self.client.get_finger_protected_currents)
+
+    def set_finger_protected_currents(self, currents: Sequence[int]) -> None:
+        """Set protected currents for all fingers (Revo2 only). Protected current is the threshold for stall detection.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            protected_currents: Current array (length 6)
+
+        Example::
+
+            hand.set_finger_protected_currents([500] * 6)
+        """
+        self.run_sdk(self.client.set_finger_protected_currents, list(currents))
+
+    def get_thumb_aux_lock_current(self) -> Optional[int]:
+        """Get thumb auxiliary motor lock current (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            int: Lock current value
+
+        Example::
+
+            lock = hand.get_thumb_aux_lock_current()
+        """
+        return self.run_sdk(self.client.get_thumb_aux_lock_current)
+
+    def set_thumb_aux_lock_current(self, lock_current: int) -> None:
+        """Set thumb auxiliary motor lock current (Revo2 only).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            lock_current: Lock current value
+
+        Example::
+
+            hand.set_thumb_aux_lock_current(100)
+        """
+        self.run_sdk(self.client.set_thumb_aux_lock_current, lock_current)
+
+    # --- touch sensor ---
+
+    def get_touch_sensor_enabled(self) -> Optional[int]:
+        """Get which touch sensors are enabled.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            int: Bitmask of enabled sensors (bit 0-4 for each finger)
+
+        Example::
+
+            mask = hand.get_touch_sensor_enabled()  # bit i = finger i
+        """
+        return self.run_sdk(self.client.get_touch_sensor_enabled)
+
+    def get_touch_sensor_fw_versions(self) -> Optional[List[str]]:
+        """Get touch sensor firmware versions.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            list: Firmware versions for each touch sensor
+
+        Example::
+
+            vers = hand.get_touch_sensor_fw_versions()
+        """
+        return self.run_sdk(self.client.get_touch_sensor_fw_versions)
+
+    def get_touch_sensor_raw_data(self) -> Optional[TouchRawData]:
+        """Get touch sensor raw data (capacitive sensors).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            TouchRawData: Raw capacitive sensor data
+
+        Example::
+
+            raw = hand.get_touch_sensor_raw_data()
+        """
+        return self.run_sdk(self.client.get_touch_sensor_raw_data)
+
+    def get_touch_sensor_status(self) -> Optional[List[TouchFingerItem]]:
+        """Get touch sensor status for all fingers (capacitive sensors).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            list[TouchFingerItem]: Capacitive status for fingers 0–4.
+
+        Example::
+
+            items = hand.get_touch_sensor_status()
+        """
+        return self.run_sdk(self.client.get_touch_sensor_status)
+
+    def get_single_touch_sensor_status(self, index: int) -> Optional[TouchFingerItem]:
+        """Get touch sensor status for a single finger (capacitive sensors).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            index: Finger index (0-4)
+
+        Returns:
+            TouchFingerItem: Capacitive status for one finger.
+
+        Example::
+
+            item = hand.get_single_touch_sensor_status(0)
+        """
+        return self.run_sdk(self.client.get_single_touch_sensor_status, index)
+
+    def touch_sensor_setup(self, bits: int) -> None:
+        """Setup touch sensors (enable/disable specific fingers).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            bits: Bitmask of sensors to enable (bit 0-4 for each finger)
+
+        Example::
+
+            hand.touch_sensor_setup(0b11111)  # enable fingers 0-4"""
+        self.run_sdk(self.client.touch_sensor_setup, bits)
+
+    def touch_sensor_reset(self, bits: int) -> None:
+        """Reset touch sensors.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            bits: Bitmask of sensors to reset (bit 0-4 for each finger)
+
+        Example::
+
+            hand.touch_sensor_reset(0b00001)  # reset finger 0"""
+        self.run_sdk(self.client.touch_sensor_reset, bits)
+
+    def touch_sensor_calibrate(self, bits: int) -> None:
+        """Calibrate touch sensors.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            bits: Bitmask of sensors to calibrate (bit 0-4 for each finger)
+
+        Example::
+
+            hand.touch_sensor_calibrate(0b11111)
+        """
+        self.run_sdk(self.client.touch_sensor_calibrate, bits)
+
+    # --- LED / buzzer / vibration ---
+
+    def get_led_enabled(self) -> Optional[bool]:
+        """Check if LED is enabled.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            bool: True if LED is enabled
+
+        Example::
+
+            on = hand.get_led_enabled()
+        """
+        return self.run_sdk(self.client.get_led_enabled)
+
+    def get_led_info(self) -> Optional[LedInfo]:
+        """Get LED information (color, mode, brightness).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            LedInfo: LED configuration
+
+        Example::
+
+            led = hand.get_led_info()
+        """
+        return self.run_sdk(self.client.get_led_info)
+
+    def set_led_enabled(self, enabled: bool) -> None:
+        """Enable or disable LED.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            enabled: True to enable, False to disable
+
+        Example::
+
+            hand.set_led_enabled(True)
+        """
+        self.run_sdk(self.client.set_led_enabled, enabled)
+
+    def set_led_info(self, led_info: LedInfo) -> None:
+        """Set LED information (color, mode, brightness).
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            led_info: LedInfo object
+
+        Example::
+
+            led = hand.LedInfo(hand.LedColor.RGB, hand.LedMode.Blink2Hz)
+            hand.set_led_info(led)
+        """
+        self.run_sdk(self.client.set_led_info, led_info)
+
+    def get_buzzer_enabled(self) -> Optional[bool]:
+        """Check if buzzer is enabled.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            bool: True if buzzer is enabled
+
+        Example::
+
+            on = hand.get_buzzer_enabled()
+        """
+        return self.run_sdk(self.client.get_buzzer_enabled)
+
+    def set_buzzer_enabled(self, enabled: bool) -> None:
+        """Enable or disable buzzer.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            enabled: True to enable, False to disable
+
+        Example::
+
+            hand.set_buzzer_enabled(True)
+        """
+        self.run_sdk(self.client.set_buzzer_enabled, enabled)
+
+    def get_vibration_enabled(self) -> Optional[bool]:
+        """Check if vibration motor is enabled.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Returns:
+            bool: True if vibration motor is enabled
+
+        Example::
+
+            on = hand.get_vibration_enabled()
+        """
+        return self.run_sdk(self.client.get_vibration_enabled)
+
+    def set_vibration_enabled(self, enabled: bool) -> None:
+        """Enable or disable vibration motor.
+
+        Wrapped bc-stark-sdk API; ``slave_id`` is routed automatically.
+
+        Args:
+            enabled: True to enable, False to disable
+
+        Example::
+
+            hand.set_vibration_enabled(True)
+        """
+        self.run_sdk(self.client.set_vibration_enabled, enabled)
+
+    # --- transport helpers ---
+
+    def scan_slave_ids(
+        self,
+        candidate_ids: Optional[Sequence[int]] = None,
+        *,
+        timeout_ms: int = 500,
+    ) -> Optional[int]:
+        """Probe wrist CAN tunnel for a touch-hand Modbus slave id.
+
+        Uses bc-stark-sdk ``scan_canfd_devices`` under the hood. Does not
+        change :attr:`hand_side` binding.
+
+        Args:
+            candidate_ids: IDs to try (default ``[0x7E, 0x7F]``).
+            timeout_ms: Probe timeout per candidate.
+
+        Returns:
+            First responding slave id, or ``None``.
+
+        Example::
+
+            sid = hand.scan_slave_ids([0x7E, 0x7F])
+        """
+        ids = list(candidate_ids) if candidate_ids is not None else None
+        return self._bridge.run(
+            self._bridge.probe_slave_id(ids, timeout_ms=timeout_ms)
+        )
+
+    def run_sdk(
+        self,
+        fn: Callable[Concatenate[int, P], Any],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Optional[T]:
+        """
+        Run a bc-stark-sdk ``DeviceContext`` method on the SDK thread.
+
+        Pass ``hand.client.<method>``; ``slave_id`` routing is injected
+        automatically. Handles both synchronous returns (e.g. capability
+        probes) and async Futures. Returns ``None`` on timeout or SDK error.
+
+        Example::
+
+            pos = hand.run_sdk(hand.client.get_finger_positions)
+            hand.run_sdk(hand.client.set_finger_positions, [0, 500, 500, 500, 500, 500])
+            hand.get_device_info()
+            hand.run_sdk(hand.client.is_touch_hand)
+        """
+        async def _once(slave_id: int) -> T:
+            return await _invoke_sdk(fn, slave_id, *args, **kwargs)
+
+        def _run(slave_id: int) -> T:
+            return self._bridge.run(_once(slave_id))
+
+        auto_mode = self._auto_mode
+        active = self._active_side
+
+        if not auto_mode:
+            if active is None:
+                raise RuntimeError("pinned hand side is not set")
+            try:
+                return _run(_device_id_for_hand(active))
+            except Exception:
+                return None
+
+        if active is None:
+            slave_id = self._probe_and_bind()
+            if slave_id is None:
+                return None
+            try:
+                return _run(slave_id)
+            except Exception:
+                self._active_side = None
+                return None
+
+        primary = _device_id_for_hand(active)
+        try:
+            return _run(primary)
+        except Exception:
+            fallback_hand = _other_hand_side(active)
+            try:
+                result = _run(_device_id_for_hand(fallback_hand))
+                self._active_side = fallback_hand
+                return result
+            except Exception:
+                self._active_side = None
+                return None
+
+    def _probe_and_bind(self) -> Optional[int]:
+        found = self._bridge.run(self._bridge.probe_slave_id())
+        if found is None:
+            return None
+        self._active_side = _hand_for_device_id(found)
+        return found

--- a/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/libstark_bridge.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/effector/revo2_touch/default/libstark_bridge.py
@@ -1,0 +1,177 @@
+"""
+Adapt ``bc-stark-sdk`` CAN FD transport to the Agilex wrist CAN 2.0 tunnel.
+
+Official SDK calls synchronous ``set_can_tx`` / ``set_can_rx`` callbacks.
+TX is fragmented onto classic CAN 0x711; RX reassembles 0x712 in the arm
+read-loop via :class:`~.....comms.Can20CanfdRx`.
+"""
+
+import asyncio
+import threading
+import time
+from typing import Any, Coroutine, Optional, TypeVar
+
+from .....comms import Can20CanfdRx, CanFdMessage
+from ....core.driver_context import DriverContext
+
+try:
+    import bc_stark_sdk.main_mod as libstark
+    from bc_stark_sdk.main_mod import DeviceContext, StarkProtocolType
+except ImportError as exc:  # pragma: no cover
+    libstark = None  # type: ignore[assignment]
+    DeviceContext = Any  # type: ignore[misc, assignment]
+    StarkProtocolType = Any  # type: ignore[misc, assignment]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+T = TypeVar("T")
+
+# BrainCo CAN FD id: (slave_id << 16) | (master_id << 8) | pdu_len
+DEFAULT_MASTER_ID = 0x08
+DEFAULT_TUNNEL_TIMEOUT_S = 0.1  # _can_rx wait; wrist tunnel may be slower on hardware
+DEFAULT_TUNNEL_GAP_S = 0.0  # pause between 0x711 fragments
+DEFAULT_PROBE_TIMEOUT_MS = 500  # scan_canfd_devices
+
+
+def _require_sdk() -> None:
+    if libstark is None:
+        raise ImportError(
+            "bc-stark-sdk is required for Revo2 touch-hand SDK support. "
+            "Install with: pip install bc-stark-sdk"
+        ) from _IMPORT_ERROR
+
+
+def _slave_id_from_can_id(can_id: int) -> int:
+    return (can_id >> 16) & 0xFF
+
+
+def _master_id_from_can_id(can_id: int) -> int:
+    return (can_id >> 8) & 0xFF
+
+
+class LibStarkBridge:
+    """
+    Run bc-stark-sdk on a dedicated asyncio thread over the wrist tunnel.
+
+    Requires the arm read-loop (``ctx.start_th()``) so 0x712 frames reach
+    :meth:`_on_can_frame`. SDK ``can_rx`` blocks that asyncio thread, not
+    the read-loop.
+    """
+
+    def __init__(
+        self,
+        ctx: DriverContext,
+        *,
+        master_id: int = DEFAULT_MASTER_ID,
+        tunnel_timeout_s: float = DEFAULT_TUNNEL_TIMEOUT_S,
+        tunnel_gap_s: float = DEFAULT_TUNNEL_GAP_S,
+    ) -> None:
+        _require_sdk()
+        self._ctx = ctx
+        self._master_id = master_id
+        self._tunnel_timeout_s = tunnel_timeout_s
+        self._tunnel_gap_s = tunnel_gap_s
+
+        self._loop = asyncio.new_event_loop()
+        self._loop_ready = threading.Event()
+        self._loop_thread = threading.Thread(
+            target=self._run_event_loop, name="revo2-touch-sdk", daemon=True
+        )
+        self._client: Optional[DeviceContext] = None
+        self._started = False
+
+        self._rx_collector = Can20CanfdRx()
+        self._rx_lock = threading.Lock()
+        ctx.register_parser_packet_fun(self._on_can_frame)
+
+    @property
+    def client(self) -> DeviceContext:
+        if self._client is None:
+            raise RuntimeError("LibStarkBridge is not started")
+        return self._client
+
+    def start(self) -> None:
+        """Register SDK callbacks and init ``DeviceContext`` (idempotent)."""
+        if self._started:
+            return
+        self._loop_thread.start()
+        if not self._loop_ready.wait(timeout=5.0):
+            raise RuntimeError("SDK event loop failed to start")
+        libstark.set_can_tx_callback(self._can_tx)
+        libstark.set_can_rx_callback(self._can_rx)
+        self._client = libstark.init_device_handler(
+            StarkProtocolType.CanFd, self._master_id
+        )
+        self._started = True
+
+    def run(self, coro: Coroutine[Any, Any, T], *, timeout: Optional[float] = None) -> T:
+        """Submit *coro* to the SDK asyncio thread and block for the result."""
+        if not self._started:
+            raise RuntimeError(
+                "LibStarkBridge is not started. "
+                "Ensure the arm read-loop is running before using the touch hand."
+            )
+        wait_s = timeout if timeout is not None else self._tunnel_timeout_s + 2.0
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=wait_s)
+
+    async def probe_slave_id(
+        self,
+        candidate_ids: Optional[list[int]] = None,
+        *,
+        timeout_ms: int = DEFAULT_PROBE_TIMEOUT_MS,
+    ) -> Optional[int]:
+        """Wrap official ``scan_canfd_devices`` (default candidates 0x7E, 0x7F)."""
+        return await libstark.scan_canfd_devices(
+            self.client,
+            candidate_ids or [0x7E, 0x7F],
+            timeout_ms,
+        )
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop_ready.set()
+        self._loop.run_forever()
+
+    def _on_can_frame(self, message) -> None:
+        with self._rx_lock:
+            self._rx_collector.feed(message)
+
+    def _can_tx(self, _slave_id: int, can_id: int, data: list) -> bool:
+        comm = self._ctx.get_comm()
+        if comm is None:
+            return False
+
+        # New SDK transaction: drop stale 0x712 fragments.
+        with self._rx_lock:
+            self._rx_collector.reset()
+
+        request = CanFdMessage(can_id, bytes(data))
+        gap = self._tunnel_gap_s
+        for frame in request.msgs:
+            comm.send(frame)
+            if gap > 0:
+                time.sleep(gap)
+        return True
+
+    def _can_rx(
+        self,
+        _slave_id: int,
+        expected_can_id: int,
+        _expected_frames: int,
+    ) -> tuple[int, bytes]:
+        # Called synchronously from SDK; blocks until read-loop feeds a match.
+        expected_slave = _slave_id_from_can_id(expected_can_id)
+        expected_master = _master_id_from_can_id(expected_can_id)
+
+        def _matches(msg: CanFdMessage) -> bool:
+            return (
+                _slave_id_from_can_id(msg.arbitration_id) == expected_slave
+                and _master_id_from_can_id(msg.arbitration_id) == expected_master
+            )
+
+        got = self._rx_collector.wait_matching(self._tunnel_timeout_s, _matches)
+        if got is None:
+            return 0, bytes([])
+        return got.arbitration_id, got.data

--- a/tests/test_can20_canfd.py
+++ b/tests/test_can20_canfd.py
@@ -1,0 +1,180 @@
+"""Unit tests for CAN 2.0 -> CAN FD tunnel framing (no hardware)."""
+
+from pyAgxArm.protocols.can_protocol.comms.can20_canfd import (
+    DEFAULT_RESPONSE_ID,
+    Can20CanfdRx,
+    CanFdMessage,
+    _crc16_ccitt_false,
+    _canfd_dlc_slot,
+    _pad_to_canfd_dlc,
+)
+
+# Sample tunneled CAN FD frame (8-byte Modbus read, same shape as wrist tunnel traffic).
+_SAMPLE_ARB_ID = 0x007E0808
+_SAMPLE_PAYLOAD = bytes.fromhex("7e0407d000067b4a")
+
+
+def _sample_canfd() -> CanFdMessage:
+    return CanFdMessage(_SAMPLE_ARB_ID, _SAMPLE_PAYLOAD)
+
+
+def _response_fragments(canfd: CanFdMessage):
+    response = CanFdMessage(
+        canfd.arbitration_id,
+        canfd.data,
+        tunnel_id=DEFAULT_RESPONSE_ID,
+    )
+    return response.msgs
+
+
+def _reassemble(fragments):
+    reassembler = Can20CanfdRx._Reassembler()
+    for message in fragments:
+        result = reassembler.feed(message.arbitration_id, bytes(message.data))
+        if result is not None:
+            return result
+    raise ValueError("incomplete CAN FD tunnel message")
+
+
+def test_canfd_tx_header_and_rx_roundtrip():
+    canfd = _sample_canfd()
+
+    first_fragment = canfd.msgs[0].data
+    assert first_fragment[0] >> 4 == len(canfd.msgs)
+    assert first_fragment[1:3] == b"\x55\xAA"
+    assert len(first_fragment) == 7
+    assert all(m.arbitration_id == 0x711 for m in canfd.msgs)
+
+    result = _reassemble(_response_fragments(canfd))
+    assert result.arbitration_id == canfd.arbitration_id
+    assert result.data == canfd.data
+
+
+def test_tunnel_crc_mismatch_warns_and_still_returns_payload(capsys):
+    payload = b"\x7e\x04\x00\x00\x00\x06"
+    arb_id = 0x007E0806
+    reassembler = Can20CanfdRx._Reassembler()
+    reassembler._frame_group = 3
+    reassembler._arbitration_id = arb_id
+    reassembler._payload = bytearray(payload)
+    reassembler._next_sequence = 3
+
+    result = reassembler.feed(0x712, bytes((0x33, 0x00, 0x00)))
+    assert result is not None
+    assert result.data == payload
+    out = capsys.readouterr().out
+    assert "[WARNING] tunnel CRC mismatch" in out
+
+
+def test_rx_ignores_can_id_low_byte_for_length():
+    """Tunnel reassembly uses frame count + tail CRC, not arb_id & 0xFF."""
+    payload = bytes.fromhex("7e040000000c010203040506")
+    canfd = CanFdMessage(0x007E0806, payload)  # low byte 0x06, payload 12 bytes
+    result = _reassemble(_response_fragments(canfd))
+    assert result.data == payload
+
+
+def test_collector_feed_and_wait():
+    canfd = _sample_canfd()
+    collector = Can20CanfdRx()
+    collector.reset()
+    for response in _response_fragments(canfd):
+        collector.feed(response)
+
+    canfd_out = collector.wait(timeout=1.0)
+
+    assert canfd_out is not None
+    assert canfd_out.arbitration_id == canfd.arbitration_id
+    assert canfd_out.data == canfd.data
+
+
+def test_wait_matching_skips_non_matching_reply():
+    wrong = CanFdMessage(0x007F0807, bytes.fromhex("7f03020001518e"))
+    right = _sample_canfd()
+    collector = Can20CanfdRx()
+    collector.reset()
+    for response in _response_fragments(wrong):
+        collector.feed(response)
+    for response in _response_fragments(right):
+        collector.feed(response)
+
+    got = collector.wait_matching(
+        1.0,
+        lambda msg: msg.arbitration_id == _SAMPLE_ARB_ID,
+    )
+    assert got is not None
+    assert got.arbitration_id == _SAMPLE_ARB_ID
+    assert got.data == _SAMPLE_PAYLOAD
+
+
+def test_reassemble_real_device_712_trace():
+    """Candump shape from Nero wrist tunnel (0x7F hand reply)."""
+    from can.message import Message
+
+    frames = [
+        bytes.fromhex("31 55 AA 00 7F 08 07"),
+        bytes.fromhex("32 7F 03 02 00 01 51 8E"),
+        bytes.fromhex("33 DD 0F"),
+    ]
+    collector = Can20CanfdRx()
+    collector.reset()
+    for data in frames:
+        collector.feed(Message(arbitration_id=0x712, is_extended_id=False, data=data))
+
+    got = collector.wait(timeout=1.0)
+    assert got is not None
+    assert got.arbitration_id == 0x007F0807
+    assert got.data.hex() == "7f03020001518e"
+
+
+def test_tx_pads_to_canfd_dlc_slot():
+    """Unpadded SDK-length payload is padded before tunnel CRC/framing."""
+    payload = bytes.fromhex(
+        "7f1003fe000c1803e803e803e803e803e803e803e803e803e803e803e803e8d97e"
+    )
+    assert len(payload) == 33
+    assert _canfd_dlc_slot(len(payload)) == 48
+
+    msg = CanFdMessage(0x007F0821, payload)
+    assert msg.data == payload
+    assert _pad_to_canfd_dlc(payload) == payload + bytes(15)
+
+    tail = msg.msgs[-1].data
+    expected_crc = _crc16_ccitt_false(_pad_to_canfd_dlc(payload))
+    assert tail[1:3] == expected_crc.to_bytes(2, "little")
+
+
+def test_reassemble_device_712_trace_with_stripped_tail_padding():
+    """712 reply: board omits 11 trailing 0x00; CRC is over 64-byte CAN FD slot."""
+    from can.message import Message
+
+    frames = [
+        bytes.fromhex("A1 55 AA 00 7F 08 35"),
+        bytes.fromhex("A2 7F 03 30 00 00 00 00"),
+        bytes.fromhex("A3 00 00 00 00 00 00 00"),
+        bytes.fromhex("A4 00 00 3C 00 5A 00 51"),
+        bytes.fromhex("A5 00 51 00 51 00 51 00"),
+        bytes.fromhex("A6 91 00 A0 00 82 00 82"),
+        bytes.fromhex("A7 00 82 00 82 03 E8 03"),
+        bytes.fromhex("A8 E8 03 E8 03 E8 03 E8"),
+        bytes.fromhex("A9 03 E8 83 91"),
+        bytes.fromhex("AA 59 0C"),
+    ]
+    expected = bytes.fromhex(
+        "7f033000000000000000000000000000"
+        "3c005a005100510051005100"
+        "9100a0008200820082008203e8"
+        "03e803e803e803e803e88391"
+    )
+    assert len(expected) == 53
+    assert _canfd_dlc_slot(len(expected)) == 64
+
+    collector = Can20CanfdRx()
+    collector.reset()
+    for data in frames:
+        collector.feed(Message(arbitration_id=0x712, is_extended_id=False, data=data))
+
+    got = collector.wait(timeout=1.0)
+    assert got is not None
+    assert got.arbitration_id == 0x007F0835
+    assert got.data == expected


### PR DESCRIPTION
feat(effector): 新增 Revo2 Touch 触觉手驱动与腕部 CAN FD 隧道

- comms：新增 can20_canfd（0x711/0x712 分帧/重组）；TX/RX 按 CAN FD DLC 档位补零后算 CRC16；CRC 不匹配仅 warning，仍返回 payload
- comms：导出 Can20CanfdRx、CanFdMessage
- effector：新增 revo2_touch Driver（bc-stark-sdk 封装，67 个公开 API）；LibStarkBridge 经读循环收 0x712、发 0x711；左右手路由（0x7E/0x7F，可自动探测）
- core：OPTIONS.EFFECTOR.REVO2_TOUCH；init_effector 路由与类型 overload
- docs：新增 docs/effector/revo2_touch/revo2_touch_api.md（中英）；README 文档表增加 Revo2 Touch 入口
- tests：test_can20_canfd.py（分帧、重组、CRC、真机抓包 53→64B 等用例）

---

feat(effector): Add Revo2 Touch tactile hand driver and wrist CAN FD tunnel

- comms: add can20_canfd (0x711/0x712 fragment/reassemble); pad to CAN FD DLC slots before CRC16 on TX/RX; CRC mismatch logs warning only, payload still returned
- comms: export Can20CanfdRx and CanFdMessage
- effector: add revo2_touch Driver (bc-stark-sdk wrapper, 67 public APIs); LibStarkBridge receives 0x712 via read-loop and sends 0x711; left/right routing (0x7E/0x7F, auto-probe supported)
- core: OPTIONS.EFFECTOR.REVO2_TOUCH; init_effector routing and type overload
- docs: add docs/effector/revo2_touch/revo2_touch_api.md (EN/ZH); README documentation table links Revo2 Touch API
- tests: test_can20_canfd.py (fragmentation, reassembly, CRC, hardware capture 53→64B cases)