### PR TITLE
feat(nero): add Orbbec DaBai DCW eye-in-hand calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build
 temp
 .pytest_cache/
 .worktrees/
+/orbbec_handeye_samples.npz
+/orbbec_handeye_result.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 *.so
 temp
 .pytest_cache/
+.worktrees/

--- a/docs/nero/orbbec_dabai_handeye.md
+++ b/docs/nero/orbbec_dabai_handeye.md
@@ -1,0 +1,168 @@
+# DaBai DCW Nero 手眼标定与使用
+
+本文面向 Ubuntu 22.04、已激活 Conda 环境 `pyagxarm` 的工程师：Orbbec DaBai DCW 固定在 Nero 法兰，机器人通过 SocketCAN `can_piper` 通信。目标是取得 RGB/深度内参、色深外参和眼在手上变换，并将**原始深度图**像素换算到 Nero 基座坐标系。
+
+## 范围与软件
+
+- 相机：Orbbec DaBai DCW；SDK：Orbbec SDK v1。
+- 官方源码：[OrbbecSDK](https://github.com/orbbec/OrbbecSDK)、[pyorbbecsdk](https://github.com/orbbec/pyorbbecsdk/tree/main)。使用 `pyorbbecsdk` 的 `main` 分支，Python 模块名为 `pyorbbecsdk`。
+- 项目校准脚本：`pyAgxArm/demos/nero/orbbec_handeye_calib.py`。
+- `pytest` 只用于测试，不是运行校准程序的运行时依赖。
+
+## 安装 SDK v1
+
+先激活目标环境，之后始终使用其 `python`，不要用系统 Python：
+
+```bash
+conda activate pyagxarm
+which python
+sudo apt update
+sudo apt install -y cmake build-essential python3-dev libusb-1.0-0-dev
+git clone --depth 1 --branch main https://github.com/orbbec/pyorbbecsdk.git
+cd pyorbbecsdk
+python -m pip install -r requirements.txt
+cmake -S . -B build \
+  -DPython3_ROOT_DIR="$CONDA_PREFIX" \
+  -Dpybind11_DIR="$(pybind11-config --cmakedir)"
+cmake --build build -j"$(nproc)"
+cmake --install build
+python -m pip install .
+sudo bash scripts/install_udev_rules.sh
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+安装或刷新 udev 规则后，拔下再插入 DaBai DCW，再验证：
+
+```bash
+python examples/hello_orbbec.py
+```
+
+当前环境中的 `opencv-contrib-python 5.0.0.93` 虽暴露了相关常量，却没有 `cv2.calibrateHandEye`。校准前安装稳定版本（或明确限制为 `<5`），并确认 API 存在：
+
+```bash
+python -m pip install --upgrade 'opencv-contrib-python==4.13.0.92'
+python -c 'import cv2; print(cv2.__version__, hasattr(cv2, "calibrateHandEye"))'
+```
+
+最后一条必须输出 `True`。如项目中同时安装了其他 OpenCV wheel，先清理冲突版本后再只保留一个 `opencv-contrib-python`。
+
+## CAN 与硬件预检
+
+确认 `can_piper` 已启动且比特率为 1 Mbps：
+
+```bash
+ip -details link show can_piper
+candump can_piper
+```
+
+第一条输出应包含 `bitrate 1000000`；第二条在机器人已上电、总线接线正确且有报文时应持续显示流量。先断电再调整 CAN/电源接线，核对终端电阻、极性和共地；不要在接线或安装相机时给机械臂上电。本流程不发送任何自主运动命令：只在机器人处于安全、人工确认的静止姿态时读取法兰位姿。
+
+## 采集与求解
+
+将棋盘固定在工作空间内，使用 **10 x 7 个内角点**、方格边长 **0.02 m**。从仓库根目录运行：
+
+```bash
+conda activate pyagxarm
+python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
+  --checkerboard-cols 10 \
+  --checkerboard-rows 7 \
+  --square-size 0.02 \
+  --can-interface socketcan \
+  --can-channel can_piper
+```
+
+画面中棋盘被检测到后，在每个由操作者安全摆放并静止的姿态按键：
+
+- `s`：保存当前有效棋盘观测与当前法兰位姿。
+- `c`：求解并写入标定 JSON。
+- `q` 或 `ESC`：退出并关闭相机、机器人连接及窗口。
+
+采集 15--30 个样本。每次既要改变平移，也要围绕至少两个不共线的旋转轴改变姿态；只沿单一轴转动会被运动多样性检查拒绝，因为手眼方程退化，无法可靠估计完整的刚体变换。棋盘必须固定不动，采样时避免振动、遮挡、反光和运动模糊。
+
+默认样本文件为 `orbbec_handeye_samples.npz`，结果为 `orbbec_handeye_result.json`。每次 `s` 都会更新 NPZ，其中保存法兰位姿、棋盘 `rvec/tvec`、时间戳、相机序列号/流配置、RGB 与深度内参、畸变、深度比例、色深外参以及棋盘几何。`--samples captures/run1` 会自动补为 `captures/run1.npz`；指定非 `.npz` 扩展名会报错。恢复旧样本时，当前相机指纹、流配置、色深外参或棋盘内角点/方格尺寸不一致会被拒绝，应重新采集而不是混用。
+
+仅对已有样本重新求解：
+
+```bash
+python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
+  --calibrate-only \
+  --samples captures/run1.npz \
+  --output captures/run1_result.json
+```
+
+结果 JSON 的 `T_color_depth`、`T_flange_color`、`T_flange_depth` 及其逆变换均会写出。所有平移和点坐标单位为米；每个变换的 `matrix_row_major_4x4` 是点转换的权威表示，XYZ/RPY 和四元数只供查看。检查 `sample_count`、`quality_warnings` 与 `consistency`，较大的棋盘基座位姿离散度表示应检查样本质量后重采。
+
+## 原始深度像素到基座
+
+约定 `T_A_B` 表示将 B 坐标系中的点映射到 A 坐标系：
+
+```text
+p_A = T_A_B * p_B
+```
+
+对于原始、未对齐的深度帧，`u` 为列、`v` 为行，取 `depth_raw = depth[v, u]`，并使用**深度内参**和 SDK 提供的 `depth_scale_m`：
+
+```text
+z = depth_raw * depth_scale_m
+p_depth = [(u-cx)z/fx, (v-cy)z/fy, z]
+p_base = T_base_flange * T_flange_depth * p_depth
+```
+
+从仓库根目录执行下例。它假设 `robot` 已按项目的 Nero 配置连接，`depth_raw_frame` 是当前 Orbbec 原始深度 `numpy` 数组；脚本目录显式加入导入路径，因此无需安装 demo 模块。
+
+```python
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+repo = Path.cwd()  # 必须是 pyAgxArm 仓库根目录
+sys.path.insert(0, str(repo / "pyAgxArm" / "demos" / "nero"))
+from orbbec_handeye_math import depth_pixel_to_base, pose6_to_matrix
+
+result = json.loads((repo / "orbbec_handeye_result.json").read_text())
+u, v = 320, 240
+depth_raw = depth_raw_frame[v, u]
+T_flange_depth = np.asarray(
+    result["T_flange_depth"]["matrix_row_major_4x4"], dtype=float
+).reshape(4, 4)
+T_base_flange = pose6_to_matrix(robot.get_flange_pose().msg)
+
+point_base_m = depth_pixel_to_base(
+    u=u,
+    v=v,
+    depth_raw=depth_raw,
+    depth_intrinsics=result["camera"]["depth_intrinsics"],
+    depth_scale_m=result["camera"]["depth_scale_m"],
+    T_flange_depth=T_flange_depth,
+    T_base_flange=T_base_flange,
+)
+print(point_base_m)
+```
+
+`depth_raw <= 0`、非有限值或无效深度必须拒绝，不能当作原点。原始未对齐深度像素绝不能使用 RGB 内参；若先做 SDK 对齐，必须同时使用与对齐后图像相对应的坐标定义和内参，不能混用。
+
+## 故障排查与验证
+
+| 现象 | 处理 |
+| --- | --- |
+| `No module named pyorbbecsdk` | 激活 `pyagxarm`，执行 `which python`，按上面的 v1 `main` 构建步骤重装，再运行 `python examples/hello_orbbec.py`。 |
+| `No device connected` 或权限错误 | 检查 USB 线和供电；重装/刷新 udev 规则后重新插拔相机。 |
+| 没有 `calibrateHandEye` | 安装 `opencv-contrib-python==4.13.0.92`，并以 `hasattr(cv2, "calibrateHandEye")` 确认 `True`。 |
+| `can_piper` 不存在或 `candump` 无报文 | 用 `ip -details link show can_piper` 检查接口和 1 Mbps，随后检查 CAN 适配器、终端电阻、接线、供电和机器人状态。 |
+| 棋盘无法检测 | 核对 10 x 7 是内角点而非方格数，保持 0.02 m 方格设置，改善照明、焦距、清晰度和完整可见性。 |
+| 样本多样性不足/同轴被拒绝 | 重采同时具有平移及至少两条不共线旋转轴的 15--30 个姿态。 |
+| 归档几何不匹配 | 不要修改旧 NPZ 的棋盘参数或混用相机配置；用当前棋盘和相机重新采集。 |
+
+运行自动化 Orbbec 测试（不连接真实硬件）：
+
+```bash
+python -m pytest -q \
+  tests/test_orbbec_handeye_math.py \
+  tests/test_orbbec_v1_camera.py \
+  tests/test_orbbec_handeye_cli.py
+```
+
+单元测试不能证明真实 DaBai 的 USB/udev/SDK 流、真实 Nero 的 CAN 通信、安装刚性、棋盘检测质量或实际手眼精度。真实验收必须在 DaBai 和 Nero 接通后进行：选一个已知棋盘点，取得其对应的有效原始深度像素，按上式变换到基座系，并与该点的物理基座测量值比较误差。只有这项硬件测量能验证深度像素到基座点的最终精度。

--- a/docs/nero/orbbec_dabai_handeye.md
+++ b/docs/nero/orbbec_dabai_handeye.md
@@ -4,8 +4,8 @@
 
 ## 范围与软件
 
-- 相机：Orbbec DaBai DCW；SDK：Orbbec SDK v1。
-- 官方源码：[OrbbecSDK](https://github.com/orbbec/OrbbecSDK)、[pyorbbecsdk](https://github.com/orbbec/pyorbbecsdk/tree/main)。使用 `pyorbbecsdk` 的 `main` 分支，Python 模块名为 `pyorbbecsdk`。
+- 相机：Orbbec DaBai DCW；它是遗留的 OpenNI 协议设备，选用支持它的 Orbbec SDK v1；SDK v2 不是本流程的选用路径。
+- 官方源码：[OrbbecSDK](https://github.com/orbbec/OrbbecSDK)、[pyorbbecsdk](https://github.com/orbbec/pyorbbecsdk/tree/main)。使用 `pyorbbecsdk` 的 `main` 分支，Python 模块名为 `pyorbbecsdk`。本指南测试的源码 revision 为 `ee32b475fdd3a433c568842597c55d29b385052e`。
 - 项目校准脚本：`pyAgxArm/demos/nero/orbbec_handeye_calib.py`。
 - `pytest` 只用于测试，不是运行校准程序的运行时依赖。
 
@@ -18,11 +18,13 @@ conda activate pyagxarm
 which python
 sudo apt update
 sudo apt install -y cmake build-essential python3-dev libusb-1.0-0-dev
-git clone --depth 1 --branch main https://github.com/orbbec/pyorbbecsdk.git
+git clone --branch main https://github.com/orbbec/pyorbbecsdk.git
 cd pyorbbecsdk
+git checkout ee32b475fdd3a433c568842597c55d29b385052e
 python -m pip install -r requirements.txt
 cmake -S . -B build \
   -DPython3_ROOT_DIR="$CONDA_PREFIX" \
+  -DCMAKE_INSTALL_PREFIX="$PWD/install" \
   -Dpybind11_DIR="$(pybind11-config --cmakedir)"
 cmake --build build -j"$(nproc)"
 cmake --install build
@@ -32,20 +34,27 @@ sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
 
+该 CMake 项目默认将 `CMAKE_INSTALL_PREFIX` 指向其源码目录下的 `install/`；这里仍显式设为 `"$PWD/install"`，以固定和显示安装位置。`cmake --install build` 会将构建产物写入克隆目录的 `install/`；随后 `python -m pip install .` 将该本地构建的绑定打包到当前 Conda Python。两步均不使用 `sudo`，只有 udev 规则脚本和规则刷新需要 `sudo`。如因兼容性选择更新的 revision，记录实际版本以保证可复现：
+
+```bash
+git rev-parse HEAD
+```
+
 安装或刷新 udev 规则后，拔下再插入 DaBai DCW，再验证：
 
 ```bash
 python examples/hello_orbbec.py
 ```
 
-当前环境中的 `opencv-contrib-python 5.0.0.93` 虽暴露了相关常量，却没有 `cv2.calibrateHandEye`。校准前安装稳定版本（或明确限制为 `<5`），并确认 API 存在：
+当前环境中的 `opencv-contrib-python 5.0.0.93` 虽暴露了相关常量，却没有 `cv2.calibrateHandEye`。校准前移除冲突 wheel，安装稳定版本（或明确限制为 `<5`），并确认 API 存在：
 
 ```bash
-python -m pip install --upgrade 'opencv-contrib-python==4.13.0.92'
+python -m pip uninstall -y opencv-python opencv-contrib-python opencv-python-headless opencv-contrib-python-headless
+python -m pip install --no-cache-dir opencv-contrib-python==4.13.0.92
 python -c 'import cv2; print(cv2.__version__, hasattr(cv2, "calibrateHandEye"))'
 ```
 
-最后一条必须输出 `True`。如项目中同时安装了其他 OpenCV wheel，先清理冲突版本后再只保留一个 `opencv-contrib-python`。
+最后一条必须显示版本并输出 `True`。
 
 ## CAN 与硬件预检
 
@@ -56,13 +65,20 @@ ip -details link show can_piper
 candump can_piper
 ```
 
-第一条输出应包含 `bitrate 1000000`；第二条在机器人已上电、总线接线正确且有报文时应持续显示流量。先断电再调整 CAN/电源接线，核对终端电阻、极性和共地；不要在接线或安装相机时给机械臂上电。本流程不发送任何自主运动命令：只在机器人处于安全、人工确认的静止姿态时读取法兰位姿。
+第一条输出应包含 `bitrate 1000000`；第二条在机器人已上电、总线接线正确且有报文时应持续显示流量，按 `Ctrl-C` 停止监听。`candump` 来自 `can-utils`；若命令不存在，安装它：
+
+```bash
+sudo apt install -y can-utils
+```
+
+先断电再调整 CAN/电源接线，核对终端电阻、极性和共地；不要在接线或安装相机时给机械臂上电。本流程不发送任何自主运动命令：只在机器人处于安全、人工确认的静止姿态时读取法兰位姿。
 
 ## 采集与求解
 
 将棋盘固定在工作空间内，使用 **10 x 7 个内角点**、方格边长 **0.02 m**。从仓库根目录运行：
 
 ```bash
+cd /path/to/pyAgxArm  # 替换为本仓库根目录
 conda activate pyagxarm
 python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
   --checkerboard-cols 10 \
@@ -72,7 +88,7 @@ python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
   --can-channel can_piper
 ```
 
-画面中棋盘被检测到后，在每个由操作者安全摆放并静止的姿态按键：
+画面中棋盘被检测到后，在每个由操作者安全摆放并静止的姿态按键。CLI 不对相机帧和机器人位姿做时间戳同步，严禁在机械臂运动时保存样本；严格执行“移动 -> 等待运动完成且机械臂静止 -> 观察稳定画面 -> 按 `s`”。
 
 - `s`：保存当前有效棋盘观测与当前法兰位姿。
 - `c`：求解并写入标定 JSON。
@@ -80,18 +96,31 @@ python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
 
 采集 15--30 个样本。每次既要改变平移，也要围绕至少两个不共线的旋转轴改变姿态；只沿单一轴转动会被运动多样性检查拒绝，因为手眼方程退化，无法可靠估计完整的刚体变换。棋盘必须固定不动，采样时避免振动、遮挡、反光和运动模糊。
 
-默认样本文件为 `orbbec_handeye_samples.npz`，结果为 `orbbec_handeye_result.json`。每次 `s` 都会更新 NPZ，其中保存法兰位姿、棋盘 `rvec/tvec`、时间戳、相机序列号/流配置、RGB 与深度内参、畸变、深度比例、色深外参以及棋盘几何。`--samples captures/run1` 会自动补为 `captures/run1.npz`；指定非 `.npz` 扩展名会报错。恢复旧样本时，当前相机指纹、流配置、色深外参或棋盘内角点/方格尺寸不一致会被拒绝，应重新采集而不是混用。
+默认样本文件为 `orbbec_handeye_samples.npz`，结果为 `orbbec_handeye_result.json`。每次 `s` 都会更新 NPZ，其中保存法兰位姿、棋盘 `rvec/tvec`、时间戳、相机序列号/流配置、RGB 与深度内参、畸变、深度比例、色深外参以及棋盘几何。`--samples captures/run1` 会自动补为 `captures/run1.npz`；指定非 `.npz` 扩展名会报错。恢复旧样本时，当前相机指纹、流配置、色深外参或棋盘内角点/方格尺寸不一致会被拒绝，应重新采集而不是混用；归档中的棋盘几何是权威定义。
+
+恢复兼容样本并继续采集，已有 `existing_samples.npz` 会自动加载；之后每次 `s` 都向该归档追加样本：
+
+```bash
+cd /path/to/pyAgxArm  # 替换为本仓库根目录
+conda activate pyagxarm
+python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
+  --samples existing_samples.npz \
+  --can-interface socketcan \
+  --can-channel can_piper
+```
 
 仅对已有样本重新求解：
 
 ```bash
+cd /path/to/pyAgxArm  # 替换为本仓库根目录
+conda activate pyagxarm
 python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
   --calibrate-only \
   --samples captures/run1.npz \
   --output captures/run1_result.json
 ```
 
-结果 JSON 的 `T_color_depth`、`T_flange_color`、`T_flange_depth` 及其逆变换均会写出。所有平移和点坐标单位为米；每个变换的 `matrix_row_major_4x4` 是点转换的权威表示，XYZ/RPY 和四元数只供查看。检查 `sample_count`、`quality_warnings` 与 `consistency`，较大的棋盘基座位姿离散度表示应检查样本质量后重采。
+结果 JSON 的 `T_color_depth`、`T_flange_color`、`T_flange_depth` 及其逆变换均会写出。所有平移和点坐标单位为米；每个变换的 `matrix_row_major_4x4` 是点转换的权威表示，XYZ/RPY 和四元数只供查看。检查 `sample_count`、`quality_warnings` 与 `consistency`；一致性指标仅是诊断信息，不设未经验证的数值离散度阈值。以已知点的物理测量比较作为验收关口。
 
 ## 原始深度像素到基座
 
@@ -109,7 +138,7 @@ p_depth = [(u-cx)z/fx, (v-cy)z/fy, z]
 p_base = T_base_flange * T_flange_depth * p_depth
 ```
 
-从仓库根目录执行下例。它假设 `robot` 已按项目的 Nero 配置连接，`depth_raw_frame` 是当前 Orbbec 原始深度 `numpy` 数组；脚本目录显式加入导入路径，因此无需安装 demo 模块。
+从仓库根目录执行下例。它假设 `robot` 已按项目的 Nero 配置连接，`depth_raw_frame` 是当前 Orbbec 原始深度 `numpy` 数组；脚本目录显式加入导入路径，因此无需安装 demo 模块。CLI 不对相机帧和法兰位姿做时间戳同步：必须先移动，再等待运动完成且机械臂静止，然后在同一静止时段取得深度帧和当前 `T_base_flange`；机械臂运动时绝不能计算 `p_base`。
 
 ```python
 import json
@@ -151,7 +180,7 @@ print(point_base_m)
 | `No module named pyorbbecsdk` | 激活 `pyagxarm`，执行 `which python`，按上面的 v1 `main` 构建步骤重装，再运行 `python examples/hello_orbbec.py`。 |
 | `No device connected` 或权限错误 | 检查 USB 线和供电；重装/刷新 udev 规则后重新插拔相机。 |
 | 没有 `calibrateHandEye` | 安装 `opencv-contrib-python==4.13.0.92`，并以 `hasattr(cv2, "calibrateHandEye")` 确认 `True`。 |
-| `can_piper` 不存在或 `candump` 无报文 | 用 `ip -details link show can_piper` 检查接口和 1 Mbps，随后检查 CAN 适配器、终端电阻、接线、供电和机器人状态。 |
+| `can_piper` 不存在或 `candump` 无报文 | 如缺少 `candump` 先安装 `can-utils`；用 `ip -details link show can_piper` 检查接口和 1 Mbps，随后检查 CAN 适配器、终端电阻、接线、供电和机器人状态。 |
 | 棋盘无法检测 | 核对 10 x 7 是内角点而非方格数，保持 0.02 m 方格设置，改善照明、焦距、清晰度和完整可见性。 |
 | 样本多样性不足/同轴被拒绝 | 重采同时具有平移及至少两条不共线旋转轴的 15--30 个姿态。 |
 | 归档几何不匹配 | 不要修改旧 NPZ 的棋盘参数或混用相机配置；用当前棋盘和相机重新采集。 |

--- a/docs/nero/orbbec_dabai_handeye.md
+++ b/docs/nero/orbbec_dabai_handeye.md
@@ -179,6 +179,7 @@ print(point_base_m)
 | --- | --- |
 | `No module named pyorbbecsdk` | 激活 `pyagxarm`，执行 `which python`，按上面的 v1 `main` 构建步骤重装，再运行 `python examples/hello_orbbec.py`。 |
 | `No device connected` 或权限错误 | 检查 USB 线和供电；重装/刷新 udev 规则后重新插拔相机。 |
+| `Timed out waiting for Orbbec frames` | DaBai DCW 在 USB 2.0 上启动首帧可能超过默认的 1000 ms；先重试，仍超时则追加 `--frame-timeout-ms 3000`。 |
 | 没有 `calibrateHandEye` | 安装 `opencv-contrib-python==4.13.0.92`，并以 `hasattr(cv2, "calibrateHandEye")` 确认 `True`。 |
 | `can_piper` 不存在或 `candump` 无报文 | 如缺少 `candump` 先安装 `can-utils`；用 `ip -details link show can_piper` 检查接口和 1 Mbps，随后检查 CAN 适配器、终端电阻、接线、供电和机器人状态。 |
 | 棋盘无法检测 | 核对 10 x 7 是内角点而非方格数，保持 0.02 m 方格设置，改善照明、焦距、清晰度和完整可见性。 |

--- a/docs/superpowers/plans/2026-07-10-orbbec-dabai-dcw-handeye.md
+++ b/docs/superpowers/plans/2026-07-10-orbbec-dabai-dcw-handeye.md
@@ -1,0 +1,904 @@
+# Orbbec DaBai DCW Hand-Eye Calibration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an Orbbec SDK v1 eye-in-hand calibration demo that converts raw DaBai DCW depth pixels into metric Nero base-frame points.
+
+**Architecture:** Keep hardware-independent transform and hand-eye math in one module, isolate all `pyorbbecsdk` calls in a small camera adapter, and keep robot/camera/UI orchestration in the CLI demo. The adapter normalizes Orbbec's depth-to-color translation from millimetres to metres, and every transform follows `T_A_B * p_B = p_A`.
+
+**Tech Stack:** Python 3.10, NumPy, OpenCV contrib, Orbbec SDK v1 `pyorbbecsdk`, pyAgxArm SocketCAN, pytest.
+
+---
+
+## File Map
+
+- Create `pyAgxArm/demos/nero/orbbec_handeye_math.py`: transforms, depth deprojection, sample persistence, hand-eye solver, consistency metrics, result serialization.
+- Create `pyAgxArm/demos/nero/orbbec_v1_camera.py`: lazy SDK import, device/profile selection, frame conversion, normalized camera metadata.
+- Create `pyAgxArm/demos/nero/orbbec_handeye_calib.py`: Nero connection, interactive collection, calibration-only mode, CLI and cleanup.
+- Create `tests/test_orbbec_handeye_math.py`: hardware-independent geometry, persistence, solver validation, and result schema tests.
+- Create `tests/test_orbbec_v1_camera.py`: SDK-boundary tests using lightweight fake SDK objects.
+- Create `tests/test_orbbec_handeye_cli.py`: parser defaults and collection helper tests without hardware.
+- Create `docs/nero/orbbec_dabai_handeye.md`: SDK v1 build, udev setup, calibration and depth conversion instructions.
+- Delete `pyAgxArm/demos/nero/d435i_handeye_calib.py`: obsolete temporary implementation for the incorrectly identified camera.
+- Delete `tests/test_d435i_handeye_calib.py`: replaced by Orbbec-specific tests.
+
+### Task 1: Transform And Depth Geometry Core
+
+**Files:**
+- Create: `tests/test_orbbec_handeye_math.py`
+- Create: `pyAgxArm/demos/nero/orbbec_handeye_math.py`
+
+- [ ] **Step 1: Write failing checkerboard and transform tests**
+
+Load the demo module by adding `pyAgxArm/demos/nero` to `sys.path`, then add these tests:
+
+```python
+def test_checkerboard_points_use_inner_corners_and_metres():
+    points = math3d.create_checkerboard_object_points((10, 7), 0.02)
+    assert points.shape == (70, 3)
+    np.testing.assert_allclose(points[0], [0.0, 0.0, 0.0])
+    np.testing.assert_allclose(points[-1], [0.18, 0.12, 0.0])
+
+
+def test_pose6_round_trip_uses_zyx_rpy():
+    pose = [0.1, -0.2, 0.3, 0.2, -0.1, 0.4]
+    result = math3d.matrix_to_pose6(math3d.pose6_to_matrix(pose))
+    np.testing.assert_allclose(result, pose, atol=1e-9)
+
+
+def test_named_transform_maps_child_point_to_parent():
+    transform = np.eye(4)
+    transform[:3, 3] = [1.0, 2.0, 3.0]
+    point = math3d.transform_point(transform, [0.1, 0.2, 0.3])
+    np.testing.assert_allclose(point, [1.1, 2.2, 3.3])
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: collection fails because `orbbec_handeye_math` does not exist.
+
+- [ ] **Step 3: Implement the minimal transform core**
+
+Implement these public functions with NumPy and no hardware imports:
+
+```python
+def create_checkerboard_object_points(checkerboard, square_size_m):
+    cols, rows = checkerboard
+    if cols <= 0 or rows <= 0 or square_size_m <= 0:
+        raise ValueError("Checkerboard dimensions and square size must be positive.")
+    points = np.zeros((cols * rows, 3), dtype=np.float32)
+    points[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
+    points[:, :2] *= float(square_size_m)
+    return points
+
+
+def transform_point(T_parent_child, point_child):
+    T = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    point = np.asarray(point_child, dtype=np.float64).reshape(3)
+    return (T @ np.r_[point, 1.0])[:3]
+
+
+def invert_transform(T_parent_child):
+    T = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = T[:3, :3].T
+    result[:3, 3] = -result[:3, :3] @ T[:3, 3]
+    return result
+```
+
+Implement `pose6_to_matrix()` and `matrix_to_pose6()` with the repository's ZYX roll/pitch/yaw convention:
+
+```python
+def pose6_to_matrix(pose):
+    x, y, z, roll, pitch, yaw = [float(value) for value in pose]
+    cr, sr = math.cos(roll), math.sin(roll)
+    cp, sp = math.cos(pitch), math.sin(pitch)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = [
+        [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
+        [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
+        [-sp, cp * sr, cp * cr],
+    ]
+    result[:3, 3] = [x, y, z]
+    return result
+
+
+def matrix_to_pose6(transform):
+    T = np.asarray(transform, dtype=np.float64).reshape(4, 4)
+    pitch = math.asin(float(np.clip(-T[2, 0], -1.0, 1.0)))
+    if abs(math.cos(pitch)) < 1e-9:
+        roll = 0.0
+        yaw = math.atan2(-T[0, 1], T[1, 1])
+    else:
+        roll = math.atan2(T[2, 1], T[2, 2])
+        yaw = math.atan2(T[1, 0], T[0, 0])
+    return np.array([T[0, 3], T[1, 3], T[2, 3], roll, pitch, yaw])
+```
+
+- [ ] **Step 4: Run transform tests and verify GREEN**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Write failing depth deprojection and transform-chain tests**
+
+```python
+def test_depth_pixel_to_camera_point_converts_sdk_mm_scale_to_metres():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    point = math3d.deproject_depth_pixel(420, 290, 1000, intrinsics, 0.001)
+    np.testing.assert_allclose(point, [0.2, 0.1, 1.0])
+
+
+def test_depth_pixel_to_base_uses_base_flange_then_flange_depth():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    T_flange_depth = np.eye(4)
+    T_flange_depth[:3, 3] = [0.0, 0.0, 0.1]
+    T_base_flange = np.eye(4)
+    T_base_flange[:3, 3] = [0.5, 0.0, 0.0]
+    point = math3d.depth_pixel_to_base(
+        320, 240, 1000, intrinsics, 0.001, T_flange_depth, T_base_flange
+    )
+    np.testing.assert_allclose(point, [0.5, 0.0, 1.1])
+
+
+@pytest.mark.parametrize("depth", [0, -1, float("nan"), float("inf")])
+def test_deprojection_rejects_invalid_depth(depth):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    with pytest.raises(ValueError, match="depth"):
+        math3d.deproject_depth_pixel(320, 240, depth, intrinsics, 0.001)
+```
+
+- [ ] **Step 6: Run depth tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: failures report missing `deproject_depth_pixel` and `depth_pixel_to_base`.
+
+- [ ] **Step 7: Implement depth deprojection and composition**
+
+```python
+def deproject_depth_pixel(
+    u, v, depth_raw, intrinsics, depth_scale_m,
+    min_depth_m=0.0, max_depth_m=None,
+):
+    depth = float(depth_raw) * float(depth_scale_m)
+    if not np.isfinite(depth) or depth <= 0.0:
+        raise ValueError("depth must be finite and greater than zero")
+    if depth < float(min_depth_m) or (
+        max_depth_m is not None and depth > float(max_depth_m)
+    ):
+        raise ValueError("depth is outside the configured range")
+    fx = float(intrinsics["fx"])
+    fy = float(intrinsics["fy"])
+    if fx <= 0.0 or fy <= 0.0:
+        raise ValueError("camera focal lengths must be positive")
+    x = (float(u) - float(intrinsics["cx"])) * depth / fx
+    y = (float(v) - float(intrinsics["cy"])) * depth / fy
+    return np.array([x, y, depth], dtype=np.float64)
+
+
+def depth_pixel_to_base(
+    u, v, depth_raw, depth_intrinsics, depth_scale_m,
+    T_flange_depth, T_base_flange,
+):
+    point_depth = deproject_depth_pixel(
+        u, v, depth_raw, depth_intrinsics, depth_scale_m
+    )
+    return transform_point(
+        np.asarray(T_base_flange) @ np.asarray(T_flange_depth), point_depth
+    )
+```
+
+- [ ] **Step 8: Run the geometry tests and commit**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: all tests pass.
+
+```bash
+git add pyAgxArm/demos/nero/orbbec_handeye_math.py tests/test_orbbec_handeye_math.py
+git commit -m "feat(nero): add hand-eye transform geometry"
+```
+
+### Task 2: Orbbec SDK v1 Metadata Normalization
+
+**Files:**
+- Create: `tests/test_orbbec_v1_camera.py`
+- Create: `pyAgxArm/demos/nero/orbbec_v1_camera.py`
+
+- [ ] **Step 1: Write failing SDK metadata tests**
+
+Use `SimpleNamespace` objects so tests do not import `pyorbbecsdk`:
+
+```python
+def test_intrinsic_and_distortion_are_normalized_for_opencv():
+    intrinsic = SimpleNamespace(width=640, height=480, fx=500.0, fy=501.0, cx=319.5, cy=239.5)
+    distortion = SimpleNamespace(k1=1.0, k2=2.0, k3=3.0, k4=4.0, k5=5.0, k6=6.0, p1=0.1, p2=0.2)
+    assert camera.normalize_intrinsic(intrinsic) == {
+        "width": 640, "height": 480, "fx": 500.0, "fy": 501.0,
+        "cx": 319.5, "cy": 239.5,
+    }
+    assert camera.normalize_distortion(distortion) == [1.0, 2.0, 0.1, 0.2, 3.0, 4.0, 5.0, 6.0]
+
+
+def test_d2c_transform_is_depth_to_color_and_converts_mm_to_metres():
+    sdk_transform = SimpleNamespace(
+        rot=np.eye(3, dtype=np.float32).reshape(-1),
+        transform=np.array([10.0, -20.0, 30.0], dtype=np.float32),
+    )
+    T_color_depth = camera.normalize_d2c_transform(sdk_transform)
+    np.testing.assert_allclose(T_color_depth[:3, :3], np.eye(3))
+    np.testing.assert_allclose(T_color_depth[:3, 3], [0.01, -0.02, 0.03])
+
+
+def test_depth_scale_is_converted_from_sdk_mm_to_metres():
+    assert camera.depth_scale_mm_to_m(1.0) == pytest.approx(0.001)
+```
+
+- [ ] **Step 2: Run SDK metadata tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_v1_camera.py`
+
+Expected: collection fails because `orbbec_v1_camera` does not exist.
+
+- [ ] **Step 3: Implement pure normalization helpers and lazy SDK import**
+
+```python
+def require_orbbec_sdk():
+    try:
+        import pyorbbecsdk
+    except ImportError as exc:
+        raise RuntimeError(
+            "Orbbec SDK v1 is required. Follow docs/nero/orbbec_dabai_handeye.md."
+        ) from exc
+    return pyorbbecsdk
+
+
+def normalize_intrinsic(intrinsic):
+    return {
+        "width": int(intrinsic.width), "height": int(intrinsic.height),
+        "fx": float(intrinsic.fx), "fy": float(intrinsic.fy),
+        "cx": float(intrinsic.cx), "cy": float(intrinsic.cy),
+    }
+
+
+def normalize_distortion(distortion):
+    return [float(getattr(distortion, name)) for name in (
+        "k1", "k2", "p1", "p2", "k3", "k4", "k5", "k6"
+    )]
+
+
+def normalize_d2c_transform(extrinsic):
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = np.asarray(extrinsic.rot, dtype=np.float64).reshape(3, 3)
+    result[:3, 3] = np.asarray(extrinsic.transform, dtype=np.float64).reshape(3) / 1000.0
+    return result
+
+
+def depth_scale_mm_to_m(scale):
+    value = float(scale) / 1000.0
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError("Orbbec depth scale must be finite and positive.")
+    return value
+```
+
+- [ ] **Step 4: Run SDK metadata tests and verify GREEN**
+
+Run: `python -m pytest -q tests/test_orbbec_v1_camera.py`
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Write failing profile-selection and metadata-fingerprint tests**
+
+Test that `select_video_profile()` tries the requested profile first, falls back to `get_default_video_stream_profile()` only after an SDK exception, and returns `used_fallback=True`:
+
+```python
+class FakeProfiles:
+    def __init__(self):
+        self.requests = []
+        self.default = object()
+
+    def get_video_stream_profile(self, width, height, image_format, fps):
+        self.requests.append((width, height, image_format, fps))
+        raise RuntimeError("unsupported")
+
+    def get_default_video_stream_profile(self):
+        return self.default
+
+
+def test_profile_selection_reports_fallback():
+    profiles = FakeProfiles()
+    profile, used_fallback = camera.select_video_profile(
+        profiles, 1280, 720, 30, ("RGB", "MJPG")
+    )
+    assert profile is profiles.default
+    assert used_fallback is True
+    assert profiles.requests == [
+        (1280, 720, "RGB", 30),
+        (1280, 720, "MJPG", 30),
+    ]
+```
+
+Add a `build_camera_metadata()` test with fake device/profile objects:
+
+```python
+def test_build_camera_metadata_preserves_calibration_and_profiles():
+    intrinsic = SimpleNamespace(width=640, height=480, fx=500.0, fy=501.0, cx=319.5, cy=239.5)
+    distortion = SimpleNamespace(k1=0.0, k2=0.0, k3=0.0, k4=0.0, k5=0.0, k6=0.0, p1=0.0, p2=0.0)
+    extrinsic = SimpleNamespace(
+        rot=np.eye(3, dtype=np.float32).reshape(-1),
+        transform=np.array([10.0, 0.0, 0.0], dtype=np.float32),
+    )
+    camera_param = SimpleNamespace(
+        rgb_intrinsic=intrinsic,
+        depth_intrinsic=intrinsic,
+        rgb_distortion=distortion,
+        depth_distortion=distortion,
+        transform=extrinsic,
+    )
+    device_info = SimpleNamespace(
+        get_name=lambda: "DaBai DCW",
+        get_serial_number=lambda: "ABC",
+        get_firmware_version=lambda: "2460",
+    )
+    metadata = camera.build_camera_metadata(
+        camera_param=camera_param,
+        device_info=device_info,
+        color_profile="1280x720@30_RGB",
+        depth_profile="640x480@30_Y16",
+        depth_scale_mm=1.0,
+    )
+    assert metadata["serial"] == "ABC"
+    assert metadata["firmware"] == "2460"
+    assert metadata["depth_scale_m"] == pytest.approx(0.001)
+    assert metadata["color_profile"] == "1280x720@30_RGB"
+    assert metadata["depth_profile"] == "640x480@30_Y16"
+    np.testing.assert_allclose(
+        np.array(metadata["T_color_depth_matrix"]).reshape(4, 4)[:3, 3],
+        [0.01, 0.0, 0.0],
+    )
+```
+
+```python
+def test_metadata_fingerprint_changes_with_stream_profile():
+    first = camera.camera_fingerprint("ABC", "1280x720@30_RGB", "640x480@30_Y16")
+    second = camera.camera_fingerprint("ABC", "640x480@30_RGB", "640x480@30_Y16")
+    assert first != second
+```
+
+- [ ] **Step 6: Run profile tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_v1_camera.py`
+
+Expected: failures report missing profile and metadata functions.
+
+- [ ] **Step 7: Implement the OrbbecV1Camera adapter**
+
+Implement `OrbbecV1Camera.start()` using the verified v1 API sequence:
+
+```python
+sdk = require_orbbec_sdk()
+context = sdk.Context()
+devices = context.query_devices()
+device = select_device(devices, self.serial_number)
+pipeline = sdk.Pipeline(device)
+config = sdk.Config()
+color_profile, color_fallback = select_video_profile(
+    pipeline.get_stream_profile_list(sdk.OBSensorType.COLOR_SENSOR),
+    self.color_width, self.color_height, self.fps,
+    (sdk.OBFormat.RGB, sdk.OBFormat.MJPG, sdk.OBFormat.YUYV),
+)
+depth_profile, depth_fallback = select_default_depth_profile(
+    pipeline.get_stream_profile_list(sdk.OBSensorType.DEPTH_SENSOR)
+)
+config.enable_stream(color_profile)
+config.enable_stream(depth_profile)
+config.set_align_mode(sdk.OBAlignMode.DISABLE)
+pipeline.enable_frame_sync()
+pipeline.start(config)
+camera_param = pipeline.get_camera_param()
+```
+
+`wait_for_frames()` must return a BGR color image, raw `uint16` depth image, depth scale in metres, and timestamps. Copy the official v1 format handling for RGB, BGR, MJPG, YUYV, I420, NV12, NV21, and UYVY. `stop()` must be idempotent.
+
+- [ ] **Step 8: Run adapter tests and commit**
+
+Run: `python -m pytest -q tests/test_orbbec_v1_camera.py`
+
+Expected: all tests pass without `pyorbbecsdk` installed.
+
+```bash
+git add pyAgxArm/demos/nero/orbbec_v1_camera.py tests/test_orbbec_v1_camera.py
+git commit -m "feat(nero): add Orbbec SDK v1 camera adapter"
+```
+
+### Task 3: Sample Persistence And Hand-Eye Solver
+
+**Files:**
+- Modify: `pyAgxArm/demos/nero/orbbec_handeye_math.py`
+- Modify: `tests/test_orbbec_handeye_math.py`
+
+- [ ] **Step 1: Write failing sample metadata and motion-validation tests**
+
+```python
+def test_load_samples_rejects_camera_fingerprint_mismatch(tmp_path):
+    path = tmp_path / "samples.npz"
+    samples = [{
+        "flange_pose": [0.0] * 6,
+        "target_rvec": np.zeros((3, 1)),
+        "target_tvec": np.ones((3, 1)),
+        "timestamp": 1.0,
+    }]
+    metadata = {"serial": "camera-A", "color_profile": "A", "depth_profile": "B"}
+    math3d.save_samples(path, samples, metadata)
+    with pytest.raises(ValueError, match="different camera or stream profile"):
+        math3d.load_samples(path, expected_fingerprint="camera-B")
+
+
+def test_samples_round_trip_full_camera_metadata(tmp_path):
+    path = tmp_path / "samples.npz"
+    metadata = {
+        "serial": "camera-A",
+        "color_profile": "1280x720@30_RGB",
+        "depth_profile": "640x480@30_Y16",
+        "T_color_depth_matrix": np.eye(4).reshape(-1).tolist(),
+    }
+    math3d.save_samples(path, [], metadata)
+    samples, loaded_metadata = math3d.load_samples(path)
+    assert samples == []
+    assert loaded_metadata == metadata
+
+
+def test_validate_sample_motion_rejects_repeated_orientation():
+    samples = [{"flange_pose": [index * 0.01, 0, 0, 0, 0, 0]} for index in range(3)]
+    with pytest.raises(ValueError, match="rotation diversity"):
+        math3d.validate_sample_motion(samples)
+```
+
+- [ ] **Step 2: Run persistence tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: failures report missing persistence and validation functions.
+
+- [ ] **Step 3: Implement persistence and motion validation**
+
+Store `flange_poses`, `target_rvecs`, `target_tvecs`, `timestamps`, scalar `camera_fingerprint`, and scalar `camera_metadata_json` in compressed NPZ. `load_samples()` returns `(samples, camera_metadata)` and optionally compares `expected_fingerprint` before returning. This lets `--calibrate-only` solve without opening the camera. Require at least three samples and a maximum pairwise flange rotation of at least five degrees:
+
+```python
+def validate_sample_motion(samples):
+    if len(samples) < 3:
+        raise ValueError("At least 3 samples are required; 15-30 are recommended.")
+    rotations = [pose6_to_matrix(sample["flange_pose"])[:3, :3] for sample in samples]
+    max_angle = max(
+        rotation_angle(rotations[i].T @ rotations[j])
+        for i in range(len(rotations)) for j in range(i + 1, len(rotations))
+    )
+    if max_angle < np.deg2rad(5.0):
+        raise ValueError("Samples do not contain enough flange rotation diversity.")
+```
+
+- [ ] **Step 4: Run persistence tests and verify GREEN**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: persistence and validation tests pass.
+
+- [ ] **Step 5: Write failing solver, result-schema, and consistency tests**
+
+Build a deterministic synthetic eye-in-hand dataset from known `T_flange_color` and fixed `T_base_target`:
+
+```python
+@pytest.fixture
+def synthetic_samples():
+    cv2 = pytest.importorskip("cv2")
+    T_flange_color = math3d.pose6_to_matrix([0.05, 0.01, 0.08, 0.1, -0.05, 0.2])
+    T_base_target = math3d.pose6_to_matrix([0.6, 0.0, 0.2, 0.0, 0.0, 0.0])
+    flange_poses = [
+        [0.30, -0.20, 0.40, 0.00, 0.00, 0.00],
+        [0.35, -0.10, 0.45, 0.20, -0.10, 0.10],
+        [0.32, 0.00, 0.42, -0.20, 0.15, -0.10],
+        [0.38, 0.10, 0.46, 0.15, 0.20, 0.25],
+        [0.28, 0.18, 0.38, -0.25, -0.15, 0.20],
+        [0.40, -0.05, 0.35, 0.30, 0.10, -0.20],
+    ]
+    samples = []
+    for index, flange_pose in enumerate(flange_poses):
+        T_base_flange = math3d.pose6_to_matrix(flange_pose)
+        T_color_target = math3d.invert_transform(
+            T_base_flange @ T_flange_color
+        ) @ T_base_target
+        samples.append({
+            "flange_pose": flange_pose,
+            "target_rvec": cv2.Rodrigues(T_color_target[:3, :3])[0],
+            "target_tvec": T_color_target[:3, 3].reshape(3, 1),
+            "timestamp": float(index),
+        })
+    return samples, T_flange_color
+```
+
+Assert that `calibrate_eye_in_hand()` recovers the known transform within `1e-5`, produces `T_flange_depth = T_flange_color @ T_color_depth`, and emits finite pairwise consistency metrics.
+
+```python
+def test_result_contains_named_depth_transform(synthetic_samples):
+    samples, expected_T_flange_color = synthetic_samples
+    T_color_depth = np.eye(4)
+    T_color_depth[:3, 3] = [0.02, 0.0, 0.0]
+    result = math3d.calibrate_eye_in_hand(
+        samples,
+        T_color_depth,
+        camera_metadata={"serial": "ABC"},
+        checkerboard=(10, 7),
+        square_size_m=0.02,
+    )
+    assert result["schema_version"] == 1
+    assert result["checkerboard"] == {
+        "inner_corners": [10, 7],
+        "square_size_m": 0.02,
+    }
+    np.testing.assert_allclose(
+        np.array(result["T_flange_color"]["matrix_row_major_4x4"]).reshape(4, 4),
+        expected_T_flange_color,
+        atol=1e-5,
+    )
+    assert result["T_flange_depth"]["parent_frame"] == "flange"
+    assert result["T_flange_depth"]["child_frame"] == "depth"
+    expected_T_flange_depth = expected_T_flange_color @ T_color_depth
+    np.testing.assert_allclose(
+        np.array(result["T_flange_depth"]["matrix_row_major_4x4"]).reshape(4, 4),
+        expected_T_flange_depth,
+        atol=1e-5,
+    )
+    assert np.isfinite(result["consistency"]["translation_rms_m"])
+```
+
+- [ ] **Step 6: Run solver tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: solver/schema tests fail because the result builder is missing.
+
+- [ ] **Step 7: Implement solver, named transforms, and metrics**
+
+Call `cv2.calibrateHandEye()` with `R_gripper2base`, `t_gripper2base`, `R_target2cam`, and `t_target2cam`. Build authoritative row-major matrices with explicit frames:
+
+```python
+T_flange_color = make_transform(R_cam2gripper, t_cam2gripper)
+T_flange_depth = T_flange_color @ np.asarray(T_color_depth, dtype=np.float64)
+result = {
+    "schema_version": 1,
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "camera": camera_metadata,
+    "checkerboard": {
+        "inner_corners": [int(checkerboard[0]), int(checkerboard[1])],
+        "square_size_m": float(square_size_m),
+    },
+    "sample_count": len(samples),
+    "method": method_name.upper(),
+    "T_color_depth": named_transform("color", "depth", T_color_depth),
+    "T_depth_color": named_transform("depth", "color", invert_transform(T_color_depth)),
+    "T_flange_color": named_transform("flange", "color", T_flange_color),
+    "T_color_flange": named_transform("color", "flange", invert_transform(T_flange_color)),
+    "T_flange_depth": named_transform("flange", "depth", T_flange_depth),
+    "T_depth_flange": named_transform("depth", "flange", invert_transform(T_flange_depth)),
+    "consistency": target_consistency_metrics(samples, T_flange_color),
+}
+```
+
+Calculate pairwise translation distances and relative rotation angles between each reconstructed `T_base_target`; report mean, RMS, and maximum values in metres and degrees. Reject non-finite output before JSON serialization.
+
+- [ ] **Step 8: Run math tests and commit**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py`
+
+Expected: all math tests pass.
+
+```bash
+git add pyAgxArm/demos/nero/orbbec_handeye_math.py tests/test_orbbec_handeye_math.py
+git commit -m "feat(nero): solve and serialize Orbbec hand-eye calibration"
+```
+
+### Task 4: Interactive Orbbec Calibration CLI
+
+**Files:**
+- Create: `pyAgxArm/demos/nero/orbbec_handeye_calib.py`
+- Create: `tests/test_orbbec_handeye_cli.py`
+- Delete: `pyAgxArm/demos/nero/d435i_handeye_calib.py`
+- Delete: `tests/test_d435i_handeye_calib.py`
+
+- [ ] **Step 1: Write failing parser and sample-capture tests**
+
+```python
+def test_parser_defaults_match_dabai_setup():
+    args = cli.build_arg_parser().parse_args([])
+    assert (args.checkerboard_cols, args.checkerboard_rows) == (10, 7)
+    assert args.square_size == pytest.approx(0.02)
+    assert args.can_interface == "socketcan"
+    assert args.can_channel == "can_piper"
+    assert (args.width, args.height, args.fps) == (1280, 720, 30)
+
+
+def test_capture_sample_requires_current_detection():
+    with pytest.raises(ValueError, match="checkerboard"):
+        cli.capture_sample(None, [0.0] * 6, time.time())
+```
+
+- [ ] **Step 2: Run CLI tests and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_cli.py`
+
+Expected: collection fails because `orbbec_handeye_calib` does not exist.
+
+- [ ] **Step 3: Implement parser, robot factory, and pure capture helper**
+
+The parser must include `--checkerboard-cols`, `--checkerboard-rows`, `--square-size`, `--samples`, `--output`, `--method`, `--calibrate-only`, `--can-interface`, `--can-channel`, `--firmware`, `--camera-serial`, `--width`, `--height`, and `--fps`. Import `pyAgxArm` only inside `create_nero_robot()` so `--help` and unit tests work without CAN dependencies.
+
+```python
+def capture_sample(detection, flange_pose, timestamp):
+    if detection is None:
+        raise ValueError("checkerboard is not detected in the current frame")
+    rvec, tvec = detection
+    return {
+        "flange_pose": [float(value) for value in flange_pose],
+        "target_rvec": np.asarray(rvec, dtype=np.float64).reshape(3, 1),
+        "target_tvec": np.asarray(tvec, dtype=np.float64).reshape(3, 1),
+        "timestamp": float(timestamp),
+    }
+```
+
+- [ ] **Step 4: Run CLI unit tests and verify GREEN**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_cli.py`
+
+Expected: parser and capture tests pass.
+
+- [ ] **Step 5: Write failing checkerboard detection test**
+
+Generate a synthetic 10 x 7 inner-corner chessboard image and assert pose detection succeeds:
+
+```python
+def test_detect_checkerboard_pose_on_synthetic_board():
+    cv2 = pytest.importorskip("cv2")
+    cols, rows, square_px = 10, 7, 60
+    board = np.full(((rows + 1) * square_px, (cols + 1) * square_px), 255, np.uint8)
+    for row in range(rows + 1):
+        for col in range(cols + 1):
+            if (row + col) % 2 == 0:
+                board[
+                    row * square_px:(row + 1) * square_px,
+                    col * square_px:(col + 1) * square_px,
+                ] = 0
+    board = cv2.copyMakeBorder(board, 40, 40, 40, 40, cv2.BORDER_CONSTANT, value=255)
+    image = cv2.cvtColor(board, cv2.COLOR_GRAY2BGR)
+    height, width = image.shape[:2]
+    camera_matrix = np.array([
+        [800.0, 0.0, width / 2.0],
+        [0.0, 800.0, height / 2.0],
+        [0.0, 0.0, 1.0],
+    ])
+    ok, rvec, tvec, corners = cli.detect_checkerboard_pose(
+        image, camera_matrix, np.zeros((8, 1)), (cols, rows), 0.02
+    )
+    assert ok is True
+    assert corners.shape == (cols * rows, 1, 2)
+    assert np.isfinite(rvec).all()
+    assert tvec[2, 0] > 0.0
+```
+
+- [ ] **Step 6: Run detection test and verify RED**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_cli.py`
+
+Expected: failure reports missing `detect_checkerboard_pose`.
+
+- [ ] **Step 7: Implement collection loop and calibration-only mode**
+
+Use the Orbbec adapter's BGR image with `findChessboardCorners`, `cornerSubPix`, and `solvePnP`. In the loop:
+
+```text
+frame -> detect current checkerboard -> draw corners/axes -> waitKey
+s -> read current flange pose -> append sample -> save NPZ
+c -> validate motion -> solve -> write JSON
+q -> exit
+```
+
+Set `last_detection = None` whenever the current frame does not contain the board, so stale detections cannot be saved. Wrap camera, robot, and OpenCV resources in `try/finally`; stop the camera, disconnect the robot when supported, and call `cv2.destroyAllWindows()`.
+
+In `--calibrate-only`, load the samples and camera metadata stored at collection time, solve without opening hardware, and write the requested JSON output.
+
+- [ ] **Step 8: Remove the obsolete D435i files**
+
+Delete only the two temporary untracked D435i files listed in this task after the Orbbec tests cover their checkerboard and transform behavior.
+
+- [ ] **Step 9: Run CLI and all Orbbec tests, then commit**
+
+Run: `python -m pytest -q tests/test_orbbec_handeye_math.py tests/test_orbbec_v1_camera.py tests/test_orbbec_handeye_cli.py`
+
+Expected: all tests pass.
+
+Run: `python pyAgxArm/demos/nero/orbbec_handeye_calib.py --help`
+
+Expected: exit 0 and help lists Orbbec, checkerboard, CAN, camera, sample and output options without importing the SDK.
+
+```bash
+git add pyAgxArm/demos/nero/orbbec_handeye_calib.py tests/test_orbbec_handeye_cli.py
+git add -u pyAgxArm/demos/nero/d435i_handeye_calib.py tests/test_d435i_handeye_calib.py
+git commit -m "feat(nero): add Orbbec hand-eye calibration CLI"
+```
+
+### Task 5: DaBai DCW Setup And Operating Guide
+
+**Files:**
+- Create: `docs/nero/orbbec_dabai_handeye.md`
+
+- [ ] **Step 1: Write the SDK v1 setup guide**
+
+Document the exact target and source branch first:
+
+```text
+Camera: Orbbec DaBai DCW
+SDK: Orbbec SDK v1
+Python wrapper: https://github.com/orbbec/pyorbbecsdk, branch main
+Expected Python module: pyorbbecsdk
+```
+
+Include Ubuntu 22.04 setup commands that preserve the active Conda interpreter:
+
+```bash
+sudo apt update
+sudo apt install -y cmake build-essential python3-dev libusb-1.0-0-dev
+git clone --depth 1 --branch main https://github.com/orbbec/pyorbbecsdk.git
+cd pyorbbecsdk
+python -m pip install -r requirements.txt
+cmake -S . -B build \
+  -DPython3_ROOT_DIR="$CONDA_PREFIX" \
+  -Dpybind11_DIR="$(pybind11-config --cmakedir)"
+cmake --build build -j"$(nproc)"
+cmake --install build
+python -m pip install .
+sudo bash scripts/install_udev_rules.sh
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+State that the camera must be replugged after udev setup and verify it with:
+
+```bash
+python examples/hello_orbbec.py
+```
+
+- [ ] **Step 2: Document calibration operation and pose diversity**
+
+Use the actual interface discovered on this workstation:
+
+```bash
+python pyAgxArm/demos/nero/orbbec_handeye_calib.py \
+  --checkerboard-cols 10 \
+  --checkerboard-rows 7 \
+  --square-size 0.02 \
+  --can-interface socketcan \
+  --can-channel can_piper
+```
+
+Explain `s`, `c`, `q`, 15-30 varied poses, fixed checkerboard, motion safety, output files, transform naming, metre units, and how to inspect consistency metrics.
+
+- [ ] **Step 3: Document depth-pixel conversion with a concrete example**
+
+Show how to load `T_flange_depth`, read current `T_base_flange`, obtain `depth_raw = depth[v, u]`, and call:
+
+```python
+point_base = depth_pixel_to_base(
+    u=u,
+    v=v,
+    depth_raw=depth_raw,
+    depth_intrinsics=result["camera"]["depth_intrinsics"],
+    depth_scale_m=result["camera"]["depth_scale_m"],
+    T_flange_depth=np.array(
+        result["T_flange_depth"]["matrix_row_major_4x4"], dtype=float
+    ).reshape(4, 4),
+    T_base_flange=pose6_to_matrix(robot.get_flange_pose().msg),
+)
+```
+
+Warn that `u` is the column, `v` is the row, zero depth is invalid, and raw unaligned depth pixels must use depth intrinsics.
+
+- [ ] **Step 4: Check links and commands, then commit**
+
+Run: `rg -n "TBD|TODO|D435|RealSense|can0" docs/nero/orbbec_dabai_handeye.md`
+
+Expected: no output.
+
+Run: `git diff --check -- docs/nero/orbbec_dabai_handeye.md`
+
+Expected: exit 0.
+
+```bash
+git add docs/nero/orbbec_dabai_handeye.md
+git commit -m "docs(nero): add DaBai DCW hand-eye guide"
+```
+
+### Task 6: Final Automated And Hardware-Gated Verification
+
+**Files:**
+- Modify only if verification reveals a defect in the files created above.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+python -m pytest -q \
+  tests/test_orbbec_handeye_math.py \
+  tests/test_orbbec_v1_camera.py \
+  tests/test_orbbec_handeye_cli.py
+```
+
+Expected: all focused tests pass with zero failures.
+
+- [ ] **Step 2: Run the full repository test suite**
+
+Run: `python -m pytest -q`
+
+Expected: all repository tests pass. If virtual-CAN support is unavailable, record the exact skipped or failed hardware dependency instead of claiming a full pass.
+
+- [ ] **Step 3: Compile and inspect CLI entry points**
+
+Run:
+
+```bash
+python -m py_compile \
+  pyAgxArm/demos/nero/orbbec_handeye_math.py \
+  pyAgxArm/demos/nero/orbbec_v1_camera.py \
+  pyAgxArm/demos/nero/orbbec_handeye_calib.py
+```
+
+Expected: exit 0.
+
+Run: `python pyAgxArm/demos/nero/orbbec_handeye_calib.py --help`
+
+Expected: exit 0 without requiring connected hardware.
+
+- [ ] **Step 4: Probe the real Orbbec SDK and camera**
+
+After the user installs SDK v1 and udev rules, run:
+
+```bash
+python -c "from pyorbbecsdk import Context; d=Context().query_devices(); print(d.get_count())"
+```
+
+Expected on this workstation: `1` or greater.
+
+Start the calibration demo and verify synchronized color/depth acquisition, the selected profiles, serial number, firmware, depth scale, and checkerboard overlay. Do not claim this step passed when the SDK or physical camera is unavailable.
+
+- [ ] **Step 5: Verify the real robot and calibration output**
+
+With Nero powered and `can_piper` active, collect 15-30 samples and press `c`. Verify that the JSON contains finite `T_flange_color`, `T_color_depth`, and `T_flange_depth` matrices and finite consistency metrics.
+
+Measure one checkerboard point in the Nero base frame, transform the corresponding valid depth pixel, and record the Euclidean error. This physical check is the final acceptance evidence for depth-to-base conversion.
+
+- [ ] **Step 6: Review the final diff and commit any verification fixes**
+
+Run: `git status --short`
+
+Expected: only pre-existing unrelated CAN-script edits remain; no generated sample NPZ or calibration JSON is staged.
+
+Run: `git diff --check`
+
+Expected: exit 0.
+
+If verification required a code correction, commit only the affected Orbbec files with:
+
+```bash
+git add pyAgxArm/demos/nero/orbbec_handeye_math.py \
+  pyAgxArm/demos/nero/orbbec_v1_camera.py \
+  pyAgxArm/demos/nero/orbbec_handeye_calib.py \
+  tests/test_orbbec_handeye_math.py \
+  tests/test_orbbec_v1_camera.py \
+  tests/test_orbbec_handeye_cli.py \
+  docs/nero/orbbec_dabai_handeye.md
+git commit -m "fix(nero): verify Orbbec hand-eye workflow"
+```

--- a/docs/superpowers/specs/2026-07-10-orbbec-dabai-dcw-handeye-design.md
+++ b/docs/superpowers/specs/2026-07-10-orbbec-dabai-dcw-handeye-design.md
@@ -1,0 +1,224 @@
+# Nero + Orbbec DaBai DCW Eye-in-Hand Calibration Design
+
+## Goal
+
+Add an eye-in-hand calibration workflow for an Orbbec DaBai DCW mounted on the
+Nero flange. The workflow must produce the transforms and camera parameters
+needed to convert a raw depth pixel or depth-camera 3D point into the Nero base
+coordinate system.
+
+The calibration target is a fixed checkerboard with 10 x 7 inner corners and a
+0.02 m square size.
+
+## Scope
+
+The implementation will:
+
+- use the Orbbec SDK v1 Python wrapper from the official `pyorbbecsdk` `main`
+  branch;
+- acquire synchronized color and depth frames from the DaBai DCW;
+- read color/depth intrinsics, distortion, depth scale, and depth-to-color
+  extrinsics from the SDK;
+- detect the checkerboard in the color image and pair each observation with the
+  current Nero flange pose;
+- calculate the camera-to-flange hand-eye transform with OpenCV;
+- derive the depth-camera-to-flange transform using the SDK extrinsics;
+- save all parameters in a versioned JSON result;
+- provide testable helpers for converting depth pixels and depth-camera points
+  into flange and base coordinates.
+
+The implementation will not perform autonomous robot motion, checkerboard
+printing, firmware upgrades, or object detection and grasp planning.
+
+## Dependencies
+
+The target environment is Ubuntu 22.04 x86_64 with Python 3.10. The Orbbec
+DaBai DCW is an Orbbec SDK v1/OpenNI-protocol device. The official
+`pyorbbecsdk` `main` branch will be built for the active `pyagxarm` environment.
+
+Required runtime packages are:
+
+- `pyorbbecsdk` v1;
+- `opencv-contrib-python`;
+- `numpy`;
+- the existing `pyAgxArm` package and Linux SocketCAN support.
+
+SDK installation and udev-rule setup will be documented separately from the
+calibration program. Missing SDK, permissions, camera streams, or CAN devices
+must produce actionable error messages.
+
+## Coordinate Convention
+
+`T_A_B` is a 4 x 4 homogeneous transform that maps a point expressed in frame
+`B` into frame `A`:
+
+```text
+p_A = T_A_B * p_B
+```
+
+All translations and 3D points are represented in metres. Homogeneous points
+are column vectors.
+
+The relevant frames are:
+
+- `base`: Nero base frame;
+- `flange`: Nero flange frame;
+- `color`: Orbbec color optical frame;
+- `depth`: Orbbec depth optical frame;
+- `target`: checkerboard frame.
+
+The Nero driver supplies `T_base_flange`. OpenCV hand-eye calibration supplies
+`T_flange_color`. The Orbbec SDK supplies `T_color_depth`. Therefore:
+
+```text
+T_flange_depth = T_flange_color * T_color_depth
+p_base = T_base_flange * T_flange_depth * p_depth
+```
+
+The implementation will normalize and validate the SDK extrinsic direction at
+its adapter boundary. Both forward and inverse transforms will be written to
+the result file with explicit frame names.
+
+## Components
+
+### Orbbec adapter
+
+A small adapter isolates SDK-specific API calls from calibration math. It will:
+
+- select the requested device by serial number, or the only attached Orbbec
+  device when no serial is supplied;
+- configure color and depth profiles;
+- return synchronized BGR color images and metric depth frames;
+- expose normalized color/depth intrinsics and `T_color_depth`;
+- convert SDK frame formats to NumPy arrays;
+- close the pipeline reliably on normal exit and errors.
+
+Depth is retained in its native optical frame for transform correctness. Color
+alignment may be displayed for diagnostics, but it will not silently change the
+coordinate frame used by conversion helpers.
+
+### Calibration collector
+
+The collector connects to Nero through the configured SocketCAN channel and
+opens the Orbbec adapter. For each color frame it detects the 10 x 7 inner
+corners, refines them to sub-pixel precision, and estimates `T_color_target`
+with the SDK color intrinsics and `solvePnP`.
+
+Keyboard controls remain:
+
+- `s`: save the current valid checkerboard observation and flange pose;
+- `c`: calculate calibration and write the result;
+- `q`: close the camera, robot connection, and window.
+
+A saved sample contains the flange pose, target rotation/translation, timestamp,
+and camera metadata fingerprint. Samples from incompatible stream profiles or
+camera serial numbers are rejected. At least three samples are mathematically
+required; fewer than fifteen produces a quality warning. The operator is told
+to collect 15-30 poses with varied translation and rotation.
+
+### Hand-eye solver
+
+The solver uses `cv2.calibrateHandEye`, with Tsai as the default and the existing
+OpenCV method choices retained. It computes `T_flange_color`, combines it with
+the SDK `T_color_depth`, and reports both transforms and their inverses.
+
+The solver also evaluates consistency of the fixed checkerboard across samples.
+It reports translation and rotation dispersion so a numerically valid but poor
+calibration is visible to the operator.
+
+### Depth conversion helpers
+
+Pure NumPy helpers will:
+
+1. deproject `(u, v, depth_raw)` using the depth intrinsics and depth scale;
+2. transform `p_depth` to `p_flange` with `T_flange_depth`;
+3. obtain the current `T_base_flange` from Nero;
+4. transform the point to `p_base`.
+
+Invalid depth values (zero, non-finite, or outside the configured range) are
+rejected instead of returning a plausible zero point.
+
+## Result Format
+
+The JSON output contains:
+
+- schema version and creation timestamp;
+- camera name, serial number, firmware version, and stream profiles;
+- checkerboard dimensions and square size in metres;
+- color and depth intrinsic matrices and distortion coefficients;
+- depth unit scale in metres per raw unit;
+- `T_color_depth` and `T_depth_color`;
+- `T_flange_color` and `T_color_flange`;
+- `T_flange_depth` and `T_depth_flange`;
+- hand-eye method, sample count, and consistency metrics.
+
+Every transform entry includes frame names, a row-major 4 x 4 matrix, XYZ/RPY,
+and quaternion representation where applicable. The matrix is authoritative for
+point conversion.
+
+## CLI
+
+The Orbbec calibration demo will preserve the existing checkerboard, CAN,
+sample, output, resolution, frame-rate, serial-number, and hand-eye-method
+options. Defaults are:
+
+```text
+checkerboard: 10 x 7 inner corners
+square size: 0.02 m
+CAN: socketcan / can_piper
+color: 1280 x 720 at 30 FPS, with a supported-profile fallback
+method: TSAI
+```
+
+The program prints the profile actually selected by the SDK. Unsupported
+profiles fail with a list of available profiles or use an explicitly reported
+fallback; they are never changed silently.
+
+## Error Handling
+
+Startup validates dependencies and hardware in this order:
+
+1. OpenCV and Orbbec SDK imports;
+2. Orbbec device discovery and permissions;
+3. color/depth profile selection and calibration data;
+4. SocketCAN device existence;
+5. Nero connection and flange-pose availability.
+
+Partial startup is unwound in reverse order. Calibration is not written when
+camera metadata changes, the transform contains non-finite values, or sample
+motion is degenerate.
+
+## Testing
+
+Hardware-independent tests cover:
+
+- conversion of Orbbec intrinsics and extrinsics into normalized matrices;
+- depth pixel deprojection and metre conversion;
+- the full `depth -> color -> flange -> base` transform chain;
+- transform inversion and frame-direction checks;
+- result JSON schema fields and round-trip loading;
+- invalid depth, incompatible sample metadata, and insufficient samples.
+
+SDK-facing tests use lightweight fake SDK objects only at the adapter boundary.
+Existing hand-eye math tests remain in place and are renamed for the Orbbec
+workflow.
+
+Hardware verification requires the real DaBai DCW and Nero:
+
+- SDK device discovery and synchronized color/depth preview;
+- checkerboard detection and 15-30 saved poses;
+- calibration consistency metrics;
+- a measured checkerboard point transformed into the base frame and compared
+  against a physical measurement.
+
+## Acceptance Criteria
+
+The feature is complete when:
+
+- the DaBai DCW color and depth streams open through Orbbec SDK v1;
+- the 10 x 7, 0.02 m checkerboard can be sampled with Nero flange poses;
+- the JSON result contains all camera calibration data and named transforms;
+- a valid raw depth pixel can be converted to a metric Nero base-frame point;
+- automated tests pass without connected hardware;
+- hardware-only verification steps and any unverified limitations are clearly
+  reported.

--- a/pyAgxArm/demos/nero/orbbec_handeye_calib.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_calib.py
@@ -40,6 +40,7 @@ def build_arg_parser():
     parser.add_argument("--width", type=int, default=1280)
     parser.add_argument("--height", type=int, default=720)
     parser.add_argument("--fps", type=int, default=30)
+    parser.add_argument("--frame-timeout-ms", type=int, default=1000)
     return parser
 
 
@@ -151,6 +152,7 @@ def create_camera(args):
         color_width=args.width,
         color_height=args.height,
         fps=args.fps,
+        timeout_ms=args.frame_timeout_ms,
     )
 
 

--- a/pyAgxArm/demos/nero/orbbec_handeye_calib.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_calib.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Interactive Orbbec/Nero eye-in-hand calibration collection utility."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+import tempfile
+import time
+
+import numpy as np
+
+from orbbec_handeye_math import (
+    calibrate_eye_in_hand,
+    create_checkerboard_object_points,
+    load_samples,
+    save_samples,
+)
+
+
+METHODS = ("TSAI", "PARK", "HORAUD", "ANDREFF", "DANIILIDIS")
+WINDOW_NAME = "Orbbec hand-eye calibration"
+
+
+def build_arg_parser():
+    """Build the command-line parser without importing optional hardware modules."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkerboard-cols", type=int, default=10)
+    parser.add_argument("--checkerboard-rows", type=int, default=7)
+    parser.add_argument("--square-size", type=float, default=0.02)
+    parser.add_argument("--samples", type=Path, default=Path("orbbec_handeye_samples.npz"))
+    parser.add_argument("--output", type=Path, default=Path("orbbec_handeye_result.json"))
+    parser.add_argument("--method", choices=METHODS, default="TSAI")
+    parser.add_argument("--calibrate-only", action="store_true")
+    parser.add_argument("--can-interface", default="socketcan")
+    parser.add_argument("--can-channel", default="can_piper")
+    parser.add_argument("--firmware", default="DEFAULT")
+    parser.add_argument("--camera-serial")
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--height", type=int, default=720)
+    parser.add_argument("--fps", type=int, default=30)
+    return parser
+
+
+def _cv2():
+    try:
+        import cv2
+    except ImportError as exc:
+        raise RuntimeError("OpenCV is required for interactive hand-eye calibration") from exc
+    return cv2
+
+
+def create_nero_robot(args):
+    """Create and connect the Nero arm only when interactive collection starts."""
+    try:
+        from pyAgxArm import AgxArmFactory, ArmModel, NeroFW, create_agx_arm_config
+    except ImportError as exc:
+        raise RuntimeError(
+            "pyAgxArm is required to connect the Nero robot. Install the package "
+            "and configure the requested CAN interface first."
+        ) from exc
+
+    firmware = getattr(NeroFW, str(args.firmware).upper(), None)
+    if firmware is None:
+        raise RuntimeError(
+            "Unknown Nero firmware {!r}; use DEFAULT, V111, V112, or V120.".format(
+                args.firmware
+            )
+        )
+    robot = None
+    try:
+        config = create_agx_arm_config(
+            robot=ArmModel.NERO,
+            firmeware_version=firmware,
+            interface=args.can_interface,
+            channel=args.can_channel,
+        )
+        robot = AgxArmFactory.create_arm(config)
+        robot.connect()
+        return robot
+    except Exception as exc:
+        if robot is not None:
+            try:
+                robot.disconnect()
+            except Exception:
+                pass
+        raise RuntimeError(
+            "Unable to connect Nero on {}:{}: {}. Check the CAN interface, "
+            "channel, power, and firmware selection.".format(
+                args.can_interface, args.can_channel, exc
+            )
+        ) from exc
+
+
+def create_camera(args):
+    """Create the lazy Orbbec adapter only for interactive collection."""
+    from orbbec_v1_camera import OrbbecV1Camera
+
+    return OrbbecV1Camera(
+        serial_number=args.camera_serial,
+        color_width=args.width,
+        color_height=args.height,
+        fps=args.fps,
+    )
+
+
+def get_flange_pose6(robot):
+    """Read one finite six-value flange pose from a Nero driver."""
+    try:
+        pose = np.asarray(robot.get_flange_pose().msg, dtype=np.float64).reshape(-1)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise RuntimeError("Nero flange pose must contain exactly six finite numbers") from exc
+    if pose.shape != (6,) or not np.all(np.isfinite(pose)):
+        raise RuntimeError("Nero flange pose must contain exactly six finite numbers")
+    return pose.tolist()
+
+
+def camera_matrix_and_distortion(metadata):
+    """Return validated color calibration arrays in OpenCV's expected layout."""
+    try:
+        intrinsic = metadata["color_intrinsics"]
+        values = [
+            float(intrinsic["fx"]),
+            float(intrinsic["fy"]),
+            float(intrinsic["cx"]),
+            float(intrinsic["cy"]),
+        ]
+        distortion = np.asarray(metadata["color_distortion"], dtype=np.float64)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("camera metadata lacks valid color intrinsics or distortion") from exc
+    fx, fy, cx, cy = values
+    if (
+        not np.all(np.isfinite(values))
+        or fx <= 0.0
+        or fy <= 0.0
+        or distortion.ndim not in (1, 2)
+        or (distortion.ndim == 2 and 1 not in distortion.shape)
+        or distortion.size == 0
+        or not np.all(np.isfinite(distortion))
+    ):
+        raise ValueError("camera metadata lacks valid color intrinsics or distortion")
+    return (
+        np.array([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=np.float64),
+        distortion.reshape(-1, 1),
+    )
+
+
+def detect_checkerboard_pose(
+    color_bgr, camera_matrix, dist_coeffs, checkerboard, square_size_m
+):
+    """Find the current checkerboard and solve its pose in the color camera frame."""
+    cv2 = _cv2()
+    gray = cv2.cvtColor(color_bgr, cv2.COLOR_BGR2GRAY)
+    flags = cv2.CALIB_CB_ADAPTIVE_THRESH | cv2.CALIB_CB_NORMALIZE_IMAGE
+    found, corners = cv2.findChessboardCorners(gray, checkerboard, flags)
+    if not found or corners is None:
+        return False, None, None, None
+
+    refined = cv2.cornerSubPix(
+        gray,
+        corners,
+        (11, 11),
+        (-1, -1),
+        (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001),
+    )
+    object_points = create_checkerboard_object_points(checkerboard, square_size_m)
+    solved, rvec, tvec = cv2.solvePnP(
+        object_points, refined, camera_matrix, dist_coeffs, flags=cv2.SOLVEPNP_ITERATIVE
+    )
+    if not solved or rvec is None or tvec is None:
+        return False, None, None, None
+    rvec = np.asarray(rvec, dtype=np.float64).reshape(3, 1)
+    tvec = np.asarray(tvec, dtype=np.float64).reshape(3, 1)
+    if not np.all(np.isfinite(rvec)) or not np.all(np.isfinite(tvec)):
+        return False, None, None, None
+    return True, rvec, tvec, refined
+
+
+def capture_sample(detection, flange_pose, timestamp):
+    """Turn a current detector result and robot pose into one persisted sample."""
+    if detection is None or not detection[0]:
+        raise ValueError("a current valid checkerboard detection is required")
+    try:
+        rvec = np.asarray(detection[1], dtype=np.float64).reshape(3, 1)
+        tvec = np.asarray(detection[2], dtype=np.float64).reshape(3, 1)
+        pose = np.asarray(flange_pose, dtype=np.float64).reshape(6)
+        timestamp = float(timestamp)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("sample fields must be numeric") from exc
+    if not all(np.all(np.isfinite(value)) for value in (rvec, tvec, pose)) or not math.isfinite(timestamp):
+        raise ValueError("sample fields must be finite")
+    return {
+        "flange_pose": pose.tolist(),
+        "target_rvec": rvec,
+        "target_tvec": tvec,
+        "timestamp": timestamp,
+    }
+
+
+def write_result_json(path, result):
+    """Write finite result JSON atomically, creating its destination directory."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        payload = json.dumps(result, ensure_ascii=True, allow_nan=False, indent=2)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("calibration result must contain only finite JSON values") from exc
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=str(destination.parent), delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(payload)
+            handle.write("\n")
+        temporary.replace(destination)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def _color_depth_transform(metadata):
+    try:
+        transform = np.asarray(metadata["T_color_depth_matrix"], dtype=np.float64).reshape(4, 4)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("camera metadata lacks a valid T_color_depth_matrix") from exc
+    if not np.all(np.isfinite(transform)):
+        raise ValueError("camera metadata lacks a valid T_color_depth_matrix")
+    return transform
+
+
+def calibrate_and_write(samples, metadata, args):
+    """Solve the current sample set and persist its JSON result."""
+    result = calibrate_eye_in_hand(
+        samples,
+        _color_depth_transform(metadata),
+        metadata,
+        checkerboard=(args.checkerboard_cols, args.checkerboard_rows),
+        square_size_m=args.square_size,
+        method_name=args.method,
+    )
+    write_result_json(args.output, result)
+    print("Calibration result written to {}".format(args.output))
+    return result
+
+
+def _metadata_compatible(saved, current):
+    if saved.get("camera_fingerprint") != current.get("camera_fingerprint"):
+        return False
+    keys = (
+        "color_profile",
+        "depth_profile",
+        "color_intrinsics",
+        "color_distortion",
+        "T_color_depth_matrix",
+    )
+    return all(saved.get(key) == current.get(key) for key in keys)
+
+
+def load_existing_samples(path, camera_metadata):
+    """Load prior samples only when they belong to this same camera configuration."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    samples, saved_metadata = load_samples(path, camera_metadata["camera_fingerprint"])
+    if not _metadata_compatible(saved_metadata, camera_metadata):
+        raise ValueError("existing sample metadata is incompatible with this camera profile")
+    return samples
+
+
+def handle_collection_key(key, detection, robot, samples, metadata, args):
+    """Process capture and calibration commands; return true only after a save."""
+    if key == ord("s"):
+        if detection is None or not detection[0]:
+            print("Skipped sample: no checkerboard is detected in the current frame.")
+            return False
+        sample = capture_sample(detection, get_flange_pose6(robot), time.time())
+        samples.append(sample)
+        Path(args.samples).parent.mkdir(parents=True, exist_ok=True)
+        save_samples(args.samples, samples, metadata)
+        print("Saved sample {} to {}".format(len(samples), args.samples))
+        return True
+    if key == ord("c"):
+        try:
+            calibrate_and_write(samples, metadata, args)
+        except (ValueError, RuntimeError) as exc:
+            print("Calibration not written: {}".format(exc))
+        return False
+    return False
+
+
+def _draw_frame(color_bgr, detection, camera_matrix, dist_coeffs, checkerboard, sample_count, camera):
+    cv2 = _cv2()
+    display = color_bgr.copy()
+    if detection is not None:
+        _, rvec, tvec, corners = detection
+        cv2.drawChessboardCorners(display, checkerboard, corners, True)
+        cv2.drawFrameAxes(display, camera_matrix, dist_coeffs, rvec, tvec, 0.06)
+        status = "detected"
+    else:
+        status = "not detected"
+    profile = "color {} | depth {}".format(camera.color_profile, camera.depth_profile)
+    cv2.putText(display, "samples: {} | board: {}".format(sample_count, status), (12, 28), cv2.FONT_HERSHEY_SIMPLEX, 0.65, (0, 255, 0) if detection else (0, 0, 255), 2)
+    cv2.putText(display, profile, (12, 56), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 0), 1)
+    cv2.imshow(WINDOW_NAME, display)
+
+
+def run_frame_loop(camera, initial_frames, robot, samples, metadata, args):
+    """Run the display/detect/capture loop with raw depth left untouched."""
+    camera_matrix, dist_coeffs = camera_matrix_and_distortion(metadata)
+    frames = initial_frames
+    while True:
+        # ``frames.depth_raw`` is intentionally neither aligned nor interpreted here.
+        found, rvec, tvec, corners = detect_checkerboard_pose(
+            frames.color_bgr,
+            camera_matrix,
+            dist_coeffs,
+            (args.checkerboard_cols, args.checkerboard_rows),
+            args.square_size,
+        )
+        last_detection = (found, rvec, tvec, corners) if found else None
+        _draw_frame(
+            frames.color_bgr,
+            last_detection,
+            camera_matrix,
+            dist_coeffs,
+            (args.checkerboard_cols, args.checkerboard_rows),
+            len(samples),
+            camera,
+        )
+        key = _cv2().waitKey(1) & 0xFF
+        if key in (ord("q"), 27):
+            return
+        handle_collection_key(key, last_detection, robot, samples, metadata, args)
+        frames = camera.wait_for_frames()
+
+
+def destroy_windows():
+    """Close OpenCV windows without importing OpenCV until collection is used."""
+    _cv2().destroyAllWindows()
+
+
+def run_collection(args):
+    """Start hardware, collect/check samples, and clean up on every exit path."""
+    camera = None
+    robot = None
+    try:
+        camera = create_camera(args)
+        camera.start()
+        initial_frames = camera.wait_for_frames()
+        metadata = camera.metadata
+        if not isinstance(metadata, dict):
+            raise RuntimeError("Orbbec did not provide camera metadata with the first frame")
+        camera_matrix_and_distortion(metadata)
+        _color_depth_transform(metadata)
+        robot = create_nero_robot(args)
+        samples = load_existing_samples(args.samples, metadata)
+        print("Checkerboard: {}x{} inner corners, {:.6g} m squares.".format(args.checkerboard_cols, args.checkerboard_rows, args.square_size))
+        print("Capture 15-30 poses with varied, non-collinear rotations for a reliable solve.")
+        run_frame_loop(camera, initial_frames, robot, samples, metadata, args)
+        return 0
+    finally:
+        if robot is not None:
+            try:
+                robot.disconnect()
+            except Exception as exc:
+                print("Nero cleanup warning: {}".format(exc))
+        if camera is not None:
+            try:
+                camera.stop()
+            except Exception as exc:
+                print("Orbbec cleanup warning: {}".format(exc))
+        try:
+            destroy_windows()
+        except Exception as exc:
+            print("OpenCV cleanup warning: {}".format(exc))
+
+
+def main(argv=None):
+    """Run the calibration command and return a shell-friendly status code."""
+    args = build_arg_parser().parse_args(argv)
+    if args.calibrate_only:
+        samples, metadata = load_samples(args.samples)
+        calibrate_and_write(samples, metadata, args)
+        return 0
+    return run_collection(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyAgxArm/demos/nero/orbbec_handeye_calib.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_calib.py
@@ -296,16 +296,24 @@ def calibrate_and_write(samples, metadata, args):
 
 
 def _metadata_compatible(saved, current):
-    if saved.get("camera_fingerprint") != current.get("camera_fingerprint"):
-        return False
     keys = (
+        "serial",
+        "firmware",
         "color_profile",
         "depth_profile",
         "color_intrinsics",
         "color_distortion",
+        "depth_intrinsics",
+        "depth_distortion",
+        "depth_scale_m",
         "T_color_depth_matrix",
     )
-    return all(saved.get(key) == current.get(key) for key in keys)
+    if not all(saved.get(key) == current.get(key) for key in keys):
+        return False
+    return (
+        "camera_fingerprint" not in saved
+        or saved["camera_fingerprint"] == current.get("camera_fingerprint")
+    )
 
 
 def load_existing_samples(path, camera_metadata, checkerboard, square_size_m):

--- a/pyAgxArm/demos/nero/orbbec_handeye_calib.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_calib.py
@@ -2,6 +2,7 @@
 """Interactive Orbbec/Nero eye-in-hand calibration collection utility."""
 
 import argparse
+import copy
 import json
 import math
 from pathlib import Path
@@ -40,6 +41,55 @@ def build_arg_parser():
     parser.add_argument("--height", type=int, default=720)
     parser.add_argument("--fps", type=int, default=30)
     return parser
+
+
+def normalize_samples_path(path):
+    """Return an NPZ sample path without silently changing named extensions."""
+    path = Path(path)
+    if not path.suffix:
+        return path.with_suffix(".npz")
+    if path.suffix != ".npz":
+        raise ValueError("sample files must use .npz extension: {}".format(path))
+    return path
+
+
+def validate_checkerboard_args(args):
+    """Validate CLI checkerboard dimensions using the shared geometry convention."""
+    checkerboard = (args.checkerboard_cols, args.checkerboard_rows)
+    square_size_m = args.square_size
+    try:
+        create_checkerboard_object_points(checkerboard, square_size_m)
+    except OverflowError as exc:
+        raise ValueError(
+            "Checkerboard dimensions must contain exactly two finite positive integers."
+        ) from exc
+    return checkerboard, float(square_size_m)
+
+
+def collection_metadata(camera_metadata, args):
+    """Copy camera metadata and bind sample collection to one checkerboard geometry."""
+    checkerboard, square_size_m = validate_checkerboard_args(args)
+    metadata = copy.deepcopy(camera_metadata)
+    metadata["checkerboard"] = {
+        "inner_corners": [int(checkerboard[0]), int(checkerboard[1])],
+        "square_size_m": square_size_m,
+    }
+    return metadata
+
+
+def stored_checkerboard_geometry(metadata):
+    """Return the validated checkerboard geometry persisted with a sample archive."""
+    try:
+        geometry = metadata["checkerboard"]
+        checkerboard = tuple(geometry["inner_corners"])
+        square_size_m = geometry["square_size_m"]
+        create_checkerboard_object_points(checkerboard, square_size_m)
+    except (KeyError, TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            "stored checkerboard geometry is missing or malformed; recapture samples "
+            "with this CLI"
+        ) from exc
+    return (int(checkerboard[0]), int(checkerboard[1])), float(square_size_m)
 
 
 def _cv2():
@@ -231,12 +281,13 @@ def _color_depth_transform(metadata):
 
 def calibrate_and_write(samples, metadata, args):
     """Solve the current sample set and persist its JSON result."""
+    checkerboard, square_size_m = stored_checkerboard_geometry(metadata)
     result = calibrate_eye_in_hand(
         samples,
         _color_depth_transform(metadata),
         metadata,
-        checkerboard=(args.checkerboard_cols, args.checkerboard_rows),
-        square_size_m=args.square_size,
+        checkerboard=checkerboard,
+        square_size_m=square_size_m,
         method_name=args.method,
     )
     write_result_json(args.output, result)
@@ -257,7 +308,7 @@ def _metadata_compatible(saved, current):
     return all(saved.get(key) == current.get(key) for key in keys)
 
 
-def load_existing_samples(path, camera_metadata):
+def load_existing_samples(path, camera_metadata, checkerboard, square_size_m):
     """Load prior samples only when they belong to this same camera configuration."""
     path = Path(path)
     if not path.exists():
@@ -265,6 +316,14 @@ def load_existing_samples(path, camera_metadata):
     samples, saved_metadata = load_samples(path, camera_metadata["camera_fingerprint"])
     if not _metadata_compatible(saved_metadata, camera_metadata):
         raise ValueError("existing sample metadata is incompatible with this camera profile")
+    saved_checkerboard, saved_square_size_m = stored_checkerboard_geometry(saved_metadata)
+    if saved_checkerboard != tuple(checkerboard) or saved_square_size_m != float(
+        square_size_m
+    ):
+        raise ValueError(
+            "existing sample checkerboard geometry does not match the current "
+            "checkerboard settings"
+        )
     return samples
 
 
@@ -345,16 +404,19 @@ def run_collection(args):
     camera = None
     robot = None
     try:
+        checkerboard, square_size_m = validate_checkerboard_args(args)
         camera = create_camera(args)
         camera.start()
         initial_frames = camera.wait_for_frames()
-        metadata = camera.metadata
-        if not isinstance(metadata, dict):
+        if not isinstance(camera.metadata, dict):
             raise RuntimeError("Orbbec did not provide camera metadata with the first frame")
+        metadata = collection_metadata(camera.metadata, args)
         camera_matrix_and_distortion(metadata)
         _color_depth_transform(metadata)
         robot = create_nero_robot(args)
-        samples = load_existing_samples(args.samples, metadata)
+        samples = load_existing_samples(
+            args.samples, metadata, checkerboard, square_size_m
+        )
         print("Checkerboard: {}x{} inner corners, {:.6g} m squares.".format(args.checkerboard_cols, args.checkerboard_rows, args.square_size))
         print("Capture 15-30 poses with varied, non-collinear rotations for a reliable solve.")
         run_frame_loop(camera, initial_frames, robot, samples, metadata, args)
@@ -379,6 +441,8 @@ def run_collection(args):
 def main(argv=None):
     """Run the calibration command and return a shell-friendly status code."""
     args = build_arg_parser().parse_args(argv)
+    validate_checkerboard_args(args)
+    args.samples = normalize_samples_path(args.samples)
     if args.calibrate_only:
         samples, metadata = load_samples(args.samples)
         calibrate_and_write(samples, metadata, args)

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -14,6 +14,19 @@ import numpy as np
 
 
 _RIGID_TRANSFORM_ATOL = 1e-9
+_ROTATION_AXIS_MIN_ANGLE_RAD = math.radians(1.0)
+_ROTATION_AXIS_CONDITIONING_MIN_RATIO = 0.05
+_SAMPLE_ARCHIVE_MEMBERS = {
+    "flange_poses.npy",
+    "target_rvecs.npy",
+    "target_tvecs.npy",
+    "timestamps.npy",
+    "camera_fingerprint.npy",
+    "camera_metadata_json.npy",
+}
+_SAMPLE_ARCHIVE_MAX_MEMBER_BYTES = 2 * 1024 * 1024
+_SAMPLE_ARCHIVE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
+_SAMPLE_ARCHIVE_MAX_COMPRESSION_RATIO = 2000.0
 
 
 def _validate_rotation(rotation):
@@ -339,6 +352,38 @@ def save_samples(path, samples, camera_metadata):
     )
 
 
+def _preflight_sample_archive(path):
+    """Validate ZIP members and declared sizes before NumPy materializes arrays."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+    except (OSError, EOFError, IOError, zipfile.BadZipFile) as exc:
+        raise ValueError("could not load sample archive: {}".format(exc)) from exc
+
+    names = [member.filename for member in members]
+    unexpected = sorted(set(names).difference(_SAMPLE_ARCHIVE_MEMBERS))
+    if unexpected:
+        raise ValueError("sample archive contains unexpected member {}".format(unexpected[0]))
+    missing = sorted(_SAMPLE_ARCHIVE_MEMBERS.difference(names))
+    if missing:
+        raise ValueError("sample archive missing required field {}".format(missing[0][:-4]))
+    if len(members) != len(_SAMPLE_ARCHIVE_MEMBERS) or len(set(names)) != len(names):
+        raise ValueError("sample archive exceeds resource limit with duplicate members")
+
+    total_size = 0
+    for member in members:
+        if member.file_size > _SAMPLE_ARCHIVE_MAX_MEMBER_BYTES:
+            raise ValueError("sample archive member exceeds resource limit")
+        total_size += member.file_size
+        if total_size > _SAMPLE_ARCHIVE_MAX_TOTAL_BYTES:
+            raise ValueError("sample archive total exceeds resource limit")
+        if member.file_size and (
+            not member.compress_size
+            or member.file_size / member.compress_size > _SAMPLE_ARCHIVE_MAX_COMPRESSION_RATIO
+        ):
+            raise ValueError("sample archive compression exceeds resource limit")
+
+
 def load_samples(path, expected_fingerprint=None):
     """Load a sample archive, rejecting malformed data and fingerprint mismatches."""
     required = {
@@ -349,6 +394,7 @@ def load_samples(path, expected_fingerprint=None):
         "camera_fingerprint",
         "camera_metadata_json",
     }
+    _preflight_sample_archive(path)
     try:
         with np.load(path, allow_pickle=False) as archive:
             missing = sorted(required.difference(archive.files))
@@ -370,8 +416,11 @@ def load_samples(path, expected_fingerprint=None):
 
     if fingerprint_data.shape != () or metadata_data.shape != ():
         raise ValueError("sample archive metadata fields must be scalar values")
+    fingerprint_item = fingerprint_data.item()
+    if not isinstance(fingerprint_item, (str, np.str_)):
+        raise ValueError("sample archive camera fingerprint must be a scalar string")
     try:
-        fingerprint = str(fingerprint_data.item())
+        fingerprint = str(fingerprint_item)
         metadata = json.loads(str(metadata_data.item()))
     except (TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ValueError("sample archive has invalid camera metadata JSON") from exc
@@ -424,6 +473,28 @@ def rotation_angle(rotation):
     return math.acos(cosine)
 
 
+def _rotation_log_vector(rotation):
+    """Return the axis-angle logarithm of a finite proper rotation matrix."""
+    matrix = _validate_rotation(rotation)
+    angle = rotation_angle(matrix)
+    if angle < _ROTATION_AXIS_MIN_ANGLE_RAD:
+        return None
+    if math.pi - angle < 1e-6:
+        eigenvalues, eigenvectors = np.linalg.eig(matrix)
+        axis = np.real(eigenvectors[:, np.argmin(np.abs(eigenvalues - 1.0))])
+        axis /= np.linalg.norm(axis)
+    else:
+        axis = np.array(
+            [
+                matrix[2, 1] - matrix[1, 2],
+                matrix[0, 2] - matrix[2, 0],
+                matrix[1, 0] - matrix[0, 1],
+            ],
+            dtype=np.float64,
+        ) / (2.0 * math.sin(angle))
+    return angle * axis
+
+
 def validate_sample_motion(samples):
     """Validate sample count and orientation diversity for hand-eye calibration."""
     normalized = _normalized_samples(samples)
@@ -434,10 +505,14 @@ def validate_sample_motion(samples):
     translations = np.asarray([transform[:3, 3] for transform in transforms])
     max_rotation = 0.0
     translation_span = 0.0
+    rotation_log_vectors = []
     for left in range(len(transforms)):
         for right in range(left + 1, len(transforms)):
             relative = invert_transform(transforms[left]) @ transforms[right]
             max_rotation = max(max_rotation, rotation_angle(relative[:3, :3]))
+            log_vector = _rotation_log_vector(relative[:3, :3])
+            if log_vector is not None:
+                rotation_log_vectors.append(log_vector)
             translation_span = max(
                 translation_span,
                 float(np.linalg.norm(translations[left] - translations[right])),
@@ -448,10 +523,24 @@ def validate_sample_motion(samples):
             "insufficient rotation diversity: capture 15-30 samples with diverse "
             "orientations (maximum relative rotation must be at least 5 degrees)"
         )
+    singular_values = np.linalg.svd(
+        np.asarray(rotation_log_vectors, dtype=np.float64), compute_uv=False
+    )
+    axis_conditioning = (
+        float(singular_values[1] / singular_values[0])
+        if len(singular_values) >= 2 and singular_values[0] > 0.0
+        else 0.0
+    )
+    if axis_conditioning < _ROTATION_AXIS_CONDITIONING_MIN_RATIO:
+        raise ValueError(
+            "insufficient non-collinear axes for rotational observability; capture "
+            "motions about at least two independent rotation axes"
+        )
     return {
         "sample_count": len(normalized),
         "max_rotation_deg": float(max_rotation_deg),
         "translation_span_m": float(translation_span),
+        "rotation_axis_conditioning": axis_conditioning,
     }
 
 

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -6,6 +6,9 @@ and pose angles are radians using ZYX roll/pitch/yaw composition.
 
 import json
 import math
+import os
+from pathlib import Path
+import tempfile
 import zipfile
 from datetime import datetime, timezone
 from numbers import Integral, Real
@@ -341,15 +344,30 @@ def save_samples(path, samples, camera_metadata):
         target_tvecs = np.empty((0, 3, 1), dtype=np.float64)
         timestamps = np.empty((0,), dtype=np.float64)
 
-    np.savez_compressed(
-        path,
-        flange_poses=flange_poses,
-        target_rvecs=target_rvecs,
-        target_tvecs=target_tvecs,
-        timestamps=timestamps,
-        camera_fingerprint=np.asarray(camera_metadata["camera_fingerprint"]),
-        camera_metadata_json=np.asarray(metadata_json),
-    )
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, prefix=".{}-".format(path.name), suffix=".npz", delete=False
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+        np.savez_compressed(
+            temp_path,
+            flange_poses=flange_poses,
+            target_rvecs=target_rvecs,
+            target_tvecs=target_tvecs,
+            timestamps=timestamps,
+            camera_fingerprint=np.asarray(camera_metadata["camera_fingerprint"]),
+            camera_metadata_json=np.asarray(metadata_json),
+        )
+        os.replace(temp_path, path)
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def _preflight_sample_archive(path):

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -1,0 +1,116 @@
+"""Hardware-independent geometry helpers for Orbbec hand-eye calibration.
+
+Transforms follow ``T_A_B @ p_B = p_A``. Translations and points are metres,
+and pose angles are radians using ZYX roll/pitch/yaw composition.
+"""
+
+import math
+
+import numpy as np
+
+
+def create_checkerboard_object_points(checkerboard, square_size_m):
+    """Return planar checkerboard inner-corner coordinates in metres."""
+    cols, rows = checkerboard
+    if cols <= 0 or rows <= 0 or square_size_m <= 0:
+        raise ValueError("Checkerboard dimensions and square size must be positive.")
+
+    points = np.zeros((cols * rows, 3), dtype=np.float64)
+    points[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
+    points[:, :2] *= float(square_size_m)
+    return points
+
+
+def pose6_to_matrix(pose):
+    """Convert ``[x, y, z, roll, pitch, yaw]`` to a homogeneous transform."""
+    x, y, z, roll, pitch, yaw = [float(value) for value in pose]
+    cr, sr = math.cos(roll), math.sin(roll)
+    cp, sp = math.cos(pitch), math.sin(pitch)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = [
+        [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
+        [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
+        [-sp, cp * sr, cp * cr],
+    ]
+    result[:3, 3] = [x, y, z]
+    return result
+
+
+def matrix_to_pose6(transform):
+    """Convert a homogeneous transform to a ZYX roll/pitch/yaw pose."""
+    T = np.asarray(transform, dtype=np.float64).reshape(4, 4)
+    pitch = math.asin(float(np.clip(-T[2, 0], -1.0, 1.0)))
+
+    if abs(math.cos(pitch)) < 1e-9:
+        roll = 0.0
+        yaw = math.atan2(-T[0, 1], T[1, 1])
+    else:
+        roll = math.atan2(T[2, 1], T[2, 2])
+        yaw = math.atan2(T[1, 0], T[0, 0])
+
+    return np.array(
+        [T[0, 3], T[1, 3], T[2, 3], roll, pitch, yaw], dtype=np.float64
+    )
+
+
+def transform_point(T_parent_child, point_child):
+    """Map a 3D point from a child frame into its parent frame."""
+    transform = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    point = np.asarray(point_child, dtype=np.float64).reshape(3)
+    return (transform @ np.r_[point, 1.0])[:3]
+
+
+def invert_transform(T_parent_child):
+    """Return the rigid inverse of a homogeneous transform."""
+    transform = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    inverse = np.eye(4, dtype=np.float64)
+    inverse[:3, :3] = transform[:3, :3].T
+    inverse[:3, 3] = -inverse[:3, :3] @ transform[:3, 3]
+    return inverse
+
+
+def deproject_depth_pixel(
+    u,
+    v,
+    depth_raw,
+    intrinsics,
+    depth_scale_m,
+    min_depth_m=0.0,
+    max_depth_m=None,
+):
+    """Deproject one raw depth pixel into the metric depth-camera frame."""
+    depth_m = float(depth_raw) * float(depth_scale_m)
+    if not np.isfinite(depth_m) or depth_m <= 0.0:
+        raise ValueError("depth must be finite and greater than zero")
+    if depth_m < float(min_depth_m) or (
+        max_depth_m is not None and depth_m > float(max_depth_m)
+    ):
+        raise ValueError("depth is outside the configured range")
+
+    fx = float(intrinsics["fx"])
+    fy = float(intrinsics["fy"])
+    if fx <= 0.0 or fy <= 0.0:
+        raise ValueError("camera focal lengths must be positive")
+
+    x = (float(u) - float(intrinsics["cx"])) * depth_m / fx
+    y = (float(v) - float(intrinsics["cy"])) * depth_m / fy
+    return np.array([x, y, depth_m], dtype=np.float64)
+
+
+def depth_pixel_to_base(
+    u,
+    v,
+    depth_raw,
+    depth_intrinsics,
+    depth_scale_m,
+    T_flange_depth,
+    T_base_flange,
+):
+    """Deproject a depth pixel and map it through flange into the base frame."""
+    point_depth = deproject_depth_pixel(
+        u, v, depth_raw, depth_intrinsics, depth_scale_m
+    )
+    T_base_depth = np.asarray(T_base_flange) @ np.asarray(T_flange_depth)
+    return transform_point(T_base_depth, point_depth)

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -4,12 +4,107 @@ Transforms follow ``T_A_B @ p_B = p_A``. Translations and points are metres,
 and pose angles are radians using ZYX roll/pitch/yaw composition.
 """
 
+import json
 import math
+import zipfile
+from datetime import datetime, timezone
 
 import numpy as np
 
 
 _RIGID_TRANSFORM_ATOL = 1e-9
+
+
+def _validate_rotation(rotation):
+    """Return a validated float64 proper rotation matrix."""
+    try:
+        result = np.asarray(rotation, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("rotation must be a numeric array with shape (3, 3)") from exc
+    if result.shape != (3, 3):
+        raise ValueError("rotation must have shape (3, 3)")
+    if not np.all(np.isfinite(result)):
+        raise ValueError("rotation must contain only finite values")
+    if not np.allclose(
+        result.T @ result, np.eye(3), rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+    ):
+        raise ValueError("rotation must be orthonormal")
+    if not np.isclose(
+        np.linalg.det(result), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+    ):
+        raise ValueError("rotation determinant must be +1")
+    return result
+
+
+def _validate_json_value(value, name):
+    """Reject non-finite values in data intended for JSON serialization."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError("{} must have string object keys".format(name))
+            _validate_json_value(child, name)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            _validate_json_value(child, name)
+    elif isinstance(value, (float, np.floating)) and not np.isfinite(value):
+        raise ValueError("{} must contain only finite numbers".format(name))
+
+
+def _validated_camera_metadata(camera_metadata):
+    if not isinstance(camera_metadata, dict):
+        raise ValueError("camera_metadata must be a JSON object")
+    fingerprint = camera_metadata.get("camera_fingerprint")
+    if not isinstance(fingerprint, str) or not fingerprint:
+        raise ValueError("camera_metadata must include a non-empty camera_fingerprint")
+    _validate_json_value(camera_metadata, "camera_metadata")
+    try:
+        metadata_json = json.dumps(
+            camera_metadata, allow_nan=False, sort_keys=True, separators=(",", ":")
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("camera_metadata must be JSON-serializable") from exc
+    return metadata_json
+
+
+def _normalized_samples(samples):
+    try:
+        items = list(samples)
+    except TypeError as exc:
+        raise ValueError("samples must be an iterable of sample objects") from exc
+
+    normalized = []
+    required = ("flange_pose", "target_rvec", "target_tvec", "timestamp")
+    for index, sample in enumerate(items):
+        if not isinstance(sample, dict):
+            raise ValueError("sample {} must be an object".format(index))
+        missing = [field for field in required if field not in sample]
+        if missing:
+            raise ValueError("sample {} missing required field {}".format(index, missing[0]))
+        try:
+            flange_pose = np.asarray(sample["flange_pose"], dtype=np.float64).reshape(6)
+            target_rvec = np.asarray(sample["target_rvec"], dtype=np.float64).reshape(3, 1)
+            target_tvec = np.asarray(sample["target_tvec"], dtype=np.float64).reshape(3, 1)
+            timestamp = float(sample["timestamp"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError("sample {} has invalid numeric fields".format(index)) from exc
+        if not (
+            np.all(np.isfinite(flange_pose))
+            and np.all(np.isfinite(target_rvec))
+            and np.all(np.isfinite(target_tvec))
+            and np.isfinite(timestamp)
+        ):
+            raise ValueError("sample {} must contain only finite values".format(index))
+        # Constructing the transform also validates any pose-derived rotation.
+        pose6_to_matrix(flange_pose)
+        normalized.append(
+            {
+                "flange_pose": flange_pose.tolist(),
+                "target_rvec": target_rvec,
+                "target_tvec": target_tvec,
+                "timestamp": timestamp,
+            }
+        )
+    return normalized
 
 
 def _validate_rigid_transform(transform):
@@ -178,3 +273,392 @@ def depth_pixel_to_base(
     )
     T_base_depth = np.asarray(T_base_flange) @ np.asarray(T_flange_depth)
     return transform_point(T_base_depth, point_depth)
+
+
+def save_samples(path, samples, camera_metadata):
+    """Save hand-eye samples in a compressed, pickle-free NPZ archive."""
+    metadata_json = _validated_camera_metadata(camera_metadata)
+    normalized = _normalized_samples(samples)
+    count = len(normalized)
+    if count:
+        flange_poses = np.asarray(
+            [sample["flange_pose"] for sample in normalized], dtype=np.float64
+        ).reshape(count, 6)
+        target_rvecs = np.stack(
+            [sample["target_rvec"] for sample in normalized]
+        ).astype(np.float64, copy=False)
+        target_tvecs = np.stack(
+            [sample["target_tvec"] for sample in normalized]
+        ).astype(np.float64, copy=False)
+        timestamps = np.asarray(
+            [sample["timestamp"] for sample in normalized], dtype=np.float64
+        )
+    else:
+        flange_poses = np.empty((0, 6), dtype=np.float64)
+        target_rvecs = np.empty((0, 3, 1), dtype=np.float64)
+        target_tvecs = np.empty((0, 3, 1), dtype=np.float64)
+        timestamps = np.empty((0,), dtype=np.float64)
+
+    np.savez_compressed(
+        path,
+        flange_poses=flange_poses,
+        target_rvecs=target_rvecs,
+        target_tvecs=target_tvecs,
+        timestamps=timestamps,
+        camera_fingerprint=np.asarray(camera_metadata["camera_fingerprint"]),
+        camera_metadata_json=np.asarray(metadata_json),
+    )
+
+
+def load_samples(path, expected_fingerprint=None):
+    """Load a sample archive, rejecting malformed data and fingerprint mismatches."""
+    required = {
+        "flange_poses",
+        "target_rvecs",
+        "target_tvecs",
+        "timestamps",
+        "camera_fingerprint",
+        "camera_metadata_json",
+    }
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            missing = sorted(required.difference(archive.files))
+            if missing:
+                raise ValueError("sample archive missing required field {}".format(missing[0]))
+            try:
+                flange_poses = np.asarray(archive["flange_poses"], dtype=np.float64)
+                target_rvecs = np.asarray(archive["target_rvecs"], dtype=np.float64)
+                target_tvecs = np.asarray(archive["target_tvecs"], dtype=np.float64)
+                timestamps = np.asarray(archive["timestamps"], dtype=np.float64)
+                fingerprint_data = archive["camera_fingerprint"]
+                metadata_data = archive["camera_metadata_json"]
+            except (TypeError, ValueError) as exc:
+                raise ValueError("sample archive has invalid numeric fields") from exc
+    except ValueError:
+        raise
+    except (OSError, EOFError, IOError, zipfile.BadZipFile) as exc:
+        raise ValueError("could not load sample archive: {}".format(exc)) from exc
+
+    if fingerprint_data.shape != () or metadata_data.shape != ():
+        raise ValueError("sample archive metadata fields must be scalar values")
+    try:
+        fingerprint = str(fingerprint_data.item())
+        metadata = json.loads(str(metadata_data.item()))
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("sample archive has invalid camera metadata JSON") from exc
+    _validated_camera_metadata(metadata)
+    if metadata["camera_fingerprint"] != fingerprint:
+        raise ValueError("sample archive camera_fingerprint does not match metadata")
+    if expected_fingerprint is not None and fingerprint != expected_fingerprint:
+        raise ValueError("sample archive camera fingerprint does not match expected fingerprint")
+
+    count = flange_poses.shape[0] if flange_poses.ndim else -1
+    expected_shapes = {
+        "flange_poses": (count, 6),
+        "target_rvecs": (count, 3, 1),
+        "target_tvecs": (count, 3, 1),
+        "timestamps": (count,),
+    }
+    actual_arrays = {
+        "flange_poses": flange_poses,
+        "target_rvecs": target_rvecs,
+        "target_tvecs": target_tvecs,
+        "timestamps": timestamps,
+    }
+    for name, expected_shape in expected_shapes.items():
+        values = actual_arrays[name]
+        if values.shape != expected_shape:
+            raise ValueError(
+                "sample archive field {} must have shape {}".format(name, expected_shape)
+            )
+        if not np.all(np.isfinite(values)):
+            raise ValueError("sample archive field {} must contain only finite values".format(name))
+
+    return (
+        [
+            {
+                "flange_pose": flange_poses[index].tolist(),
+                "target_rvec": target_rvecs[index].reshape(3, 1),
+                "target_tvec": target_tvecs[index].reshape(3, 1),
+                "timestamp": float(timestamps[index]),
+            }
+            for index in range(count)
+        ],
+        metadata,
+    )
+
+
+def rotation_angle(rotation):
+    """Return the principal angle of a finite proper rotation matrix, in radians."""
+    matrix = _validate_rotation(rotation)
+    cosine = float(np.clip((np.trace(matrix) - 1.0) / 2.0, -1.0, 1.0))
+    return math.acos(cosine)
+
+
+def validate_sample_motion(samples):
+    """Validate sample count and orientation diversity for hand-eye calibration."""
+    normalized = _normalized_samples(samples)
+    if len(normalized) < 3:
+        raise ValueError("at least 3 samples are required for hand-eye calibration")
+
+    transforms = [pose6_to_matrix(sample["flange_pose"]) for sample in normalized]
+    translations = np.asarray([transform[:3, 3] for transform in transforms])
+    max_rotation = 0.0
+    translation_span = 0.0
+    for left in range(len(transforms)):
+        for right in range(left + 1, len(transforms)):
+            relative = invert_transform(transforms[left]) @ transforms[right]
+            max_rotation = max(max_rotation, rotation_angle(relative[:3, :3]))
+            translation_span = max(
+                translation_span,
+                float(np.linalg.norm(translations[left] - translations[right])),
+            )
+    max_rotation_deg = math.degrees(max_rotation)
+    if max_rotation_deg < 5.0:
+        raise ValueError(
+            "insufficient rotation diversity: capture 15-30 samples with diverse "
+            "orientations (maximum relative rotation must be at least 5 degrees)"
+        )
+    return {
+        "sample_count": len(normalized),
+        "max_rotation_deg": float(max_rotation_deg),
+        "translation_span_m": float(translation_span),
+    }
+
+
+def make_transform(rotation, translation):
+    """Create a validated homogeneous transform from rotation and translation."""
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = _validate_rotation(rotation)
+    try:
+        vector = np.asarray(translation, dtype=np.float64).reshape(3)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("translation must be a numeric array with shape (3,)") from exc
+    if not np.all(np.isfinite(vector)):
+        raise ValueError("translation must contain only finite values")
+    result[:3, 3] = vector
+    return _validate_rigid_transform(result)
+
+
+def rotation_to_quaternion_xyzw(rotation):
+    """Convert a proper rotation matrix to a normalized ``[x, y, z, w]`` quaternion."""
+    matrix = _validate_rotation(rotation)
+    trace = float(np.trace(matrix))
+    if trace > 0.0:
+        scale = math.sqrt(trace + 1.0) * 2.0
+        quaternion = [(matrix[2, 1] - matrix[1, 2]) / scale,
+                      (matrix[0, 2] - matrix[2, 0]) / scale,
+                      (matrix[1, 0] - matrix[0, 1]) / scale, 0.25 * scale]
+    else:
+        index = int(np.argmax(np.diag(matrix)))
+        if index == 0:
+            scale = math.sqrt(1.0 + matrix[0, 0] - matrix[1, 1] - matrix[2, 2]) * 2.0
+            quaternion = [0.25 * scale, (matrix[0, 1] + matrix[1, 0]) / scale,
+                          (matrix[0, 2] + matrix[2, 0]) / scale,
+                          (matrix[2, 1] - matrix[1, 2]) / scale]
+        elif index == 1:
+            scale = math.sqrt(1.0 + matrix[1, 1] - matrix[0, 0] - matrix[2, 2]) * 2.0
+            quaternion = [(matrix[0, 1] + matrix[1, 0]) / scale, 0.25 * scale,
+                          (matrix[1, 2] + matrix[2, 1]) / scale,
+                          (matrix[0, 2] - matrix[2, 0]) / scale]
+        else:
+            scale = math.sqrt(1.0 + matrix[2, 2] - matrix[0, 0] - matrix[1, 1]) * 2.0
+            quaternion = [(matrix[0, 2] + matrix[2, 0]) / scale,
+                          (matrix[1, 2] + matrix[2, 1]) / scale, 0.25 * scale,
+                          (matrix[1, 0] - matrix[0, 1]) / scale]
+    quaternion = np.asarray(quaternion, dtype=np.float64)
+    quaternion /= np.linalg.norm(quaternion)
+    if not np.all(np.isfinite(quaternion)):
+        raise ValueError("rotation produced a non-finite quaternion")
+    return quaternion
+
+
+def named_transform(parent_frame, child_frame, transform):
+    """Return a JSON-ready, explicitly framed transform description."""
+    if not isinstance(parent_frame, str) or not parent_frame:
+        raise ValueError("parent_frame must be a non-empty string")
+    if not isinstance(child_frame, str) or not child_frame:
+        raise ValueError("child_frame must be a non-empty string")
+    matrix = _validate_rigid_transform(transform)
+    return {
+        "parent_frame": parent_frame,
+        "child_frame": child_frame,
+        "translation_m": [float(value) for value in matrix[:3, 3]],
+        "pose6_xyz_rpy": [float(value) for value in matrix_to_pose6(matrix)],
+        "quaternion_xyzw": [
+            float(value) for value in rotation_to_quaternion_xyzw(matrix[:3, :3])
+        ],
+        "matrix_row_major_4x4": [float(value) for value in matrix.reshape(-1)],
+    }
+
+
+def _rvec_to_rotation(rvec):
+    """Convert a Rodrigues vector to a rotation without requiring OpenCV."""
+    vector = np.asarray(rvec, dtype=np.float64).reshape(3)
+    if not np.all(np.isfinite(vector)):
+        raise ValueError("Rodrigues vector must contain only finite values")
+    angle = float(np.linalg.norm(vector))
+    skew = np.array(
+        [[0.0, -vector[2], vector[1]], [vector[2], 0.0, -vector[0]], [-vector[1], vector[0], 0.0]],
+        dtype=np.float64,
+    )
+    if angle < 1e-12:
+        rotation = np.eye(3) + skew + 0.5 * (skew @ skew)
+    else:
+        rotation = (
+            np.eye(3)
+            + math.sin(angle) / angle * skew
+            + (1.0 - math.cos(angle)) / (angle * angle) * (skew @ skew)
+        )
+    return _validate_rotation(rotation)
+
+
+def target_consistency_metrics(samples, T_flange_color):
+    """Measure pairwise agreement of checkerboard poses reconstructed in base frame."""
+    normalized = _normalized_samples(samples)
+    flange_color = _validate_rigid_transform(T_flange_color)
+    base_targets = []
+    for sample in normalized:
+        color_target = make_transform(
+            _rvec_to_rotation(sample["target_rvec"]), sample["target_tvec"]
+        )
+        base_targets.append(
+            pose6_to_matrix(sample["flange_pose"]) @ flange_color @ color_target
+        )
+
+    translation_distances = []
+    rotation_angles = []
+    for left in range(len(base_targets)):
+        for right in range(left + 1, len(base_targets)):
+            translation_distances.append(
+                float(
+                    np.linalg.norm(
+                        base_targets[left][:3, 3] - base_targets[right][:3, 3]
+                    )
+                )
+            )
+            relative = invert_transform(base_targets[left]) @ base_targets[right]
+            rotation_angles.append(math.degrees(rotation_angle(relative[:3, :3])))
+
+    def summary(values):
+        data = np.asarray(values, dtype=np.float64)
+        if not len(data):
+            return 0.0, 0.0, 0.0
+        return (
+            float(np.mean(data)),
+            float(math.sqrt(np.mean(data * data))),
+            float(np.max(data)),
+        )
+
+    translation_mean, translation_rms, translation_max = summary(translation_distances)
+    rotation_mean, rotation_rms, rotation_max = summary(rotation_angles)
+    metrics = {
+        "translation_mean_m": translation_mean,
+        "translation_rms_m": translation_rms,
+        "translation_max_m": translation_max,
+        "rotation_mean_deg": rotation_mean,
+        "rotation_rms_deg": rotation_rms,
+        "rotation_max_deg": rotation_max,
+    }
+    _validate_json_value(metrics, "consistency metrics")
+    return metrics
+
+
+def calibrate_eye_in_hand(
+    samples,
+    T_color_depth,
+    camera_metadata,
+    checkerboard=(10, 7),
+    square_size_m=0.02,
+    method_name="TSAI",
+):
+    """Solve and serialize an eye-in-hand calibration from checkerboard samples."""
+    if not isinstance(method_name, str):
+        raise ValueError("method_name must name a supported hand-eye method")
+    method = method_name.upper()
+    supported_methods = {"TSAI", "PARK", "HORAUD", "ANDREFF", "DANIILIDIS"}
+    if method not in supported_methods:
+        raise ValueError(
+            "unknown hand-eye method {!r}; supported methods are {}".format(
+                method_name, ", ".join(sorted(supported_methods))
+            )
+        )
+    _validated_camera_metadata(camera_metadata)
+    create_checkerboard_object_points(checkerboard, square_size_m)
+    normalized = _normalized_samples(samples)
+    motion = validate_sample_motion(normalized)
+    color_depth = _validate_rigid_transform(T_color_depth)
+
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ValueError("OpenCV is required to solve hand-eye calibration") from exc
+    if not hasattr(cv2, "calibrateHandEye"):
+        raise ValueError("this OpenCV build does not provide calibrateHandEye")
+
+    method_constants = {
+        "TSAI": cv2.CALIB_HAND_EYE_TSAI,
+        "PARK": cv2.CALIB_HAND_EYE_PARK,
+        "HORAUD": cv2.CALIB_HAND_EYE_HORAUD,
+        "ANDREFF": cv2.CALIB_HAND_EYE_ANDREFF,
+        "DANIILIDIS": cv2.CALIB_HAND_EYE_DANIILIDIS,
+    }
+    rotations_gripper_to_base = []
+    translations_gripper_to_base = []
+    rotations_target_to_camera = []
+    translations_target_to_camera = []
+    for sample in normalized:
+        base_flange = pose6_to_matrix(sample["flange_pose"])
+        rotations_gripper_to_base.append(base_flange[:3, :3])
+        translations_gripper_to_base.append(base_flange[:3, 3].reshape(3, 1))
+        rotation_target_to_camera, _ = cv2.Rodrigues(sample["target_rvec"])
+        rotations_target_to_camera.append(rotation_target_to_camera)
+        translations_target_to_camera.append(sample["target_tvec"])
+
+    try:
+        rotation_camera_to_gripper, translation_camera_to_gripper = cv2.calibrateHandEye(
+            rotations_gripper_to_base,
+            translations_gripper_to_base,
+            rotations_target_to_camera,
+            translations_target_to_camera,
+            method=method_constants[method],
+        )
+    except cv2.error as exc:
+        raise ValueError("OpenCV hand-eye calibration failed: {}".format(exc)) from exc
+    flange_color = make_transform(rotation_camera_to_gripper, translation_camera_to_gripper)
+    flange_depth = flange_color @ color_depth
+    _validate_rigid_transform(flange_depth)
+    consistency = target_consistency_metrics(normalized, flange_color)
+
+    quality_warnings = []
+    if motion["sample_count"] < 15:
+        quality_warnings.append(
+            "Only {} samples were captured; 15-30 diverse samples are recommended.".format(
+                motion["sample_count"]
+            )
+        )
+    result = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "camera": camera_metadata,
+        "checkerboard": {
+            "inner_corners": [int(checkerboard[0]), int(checkerboard[1])],
+            "square_size_m": float(square_size_m),
+        },
+        "sample_count": motion["sample_count"],
+        "method": method,
+        "quality_warnings": quality_warnings,
+        "T_color_depth": named_transform("color", "depth", color_depth),
+        "T_depth_color": named_transform("depth", "color", invert_transform(color_depth)),
+        "T_flange_color": named_transform("flange", "color", flange_color),
+        "T_color_flange": named_transform("color", "flange", invert_transform(flange_color)),
+        "T_flange_depth": named_transform("flange", "depth", flange_depth),
+        "T_depth_flange": named_transform("depth", "flange", invert_transform(flange_depth)),
+        "consistency": consistency,
+    }
+    _validate_json_value(result, "calibration result")
+    try:
+        json.dumps(result, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("calibration result is not JSON-serializable") from exc
+    return result

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -17,6 +17,7 @@ import numpy as np
 
 
 _RIGID_TRANSFORM_ATOL = 1e-9
+_RIGID_TRANSFORM_INPUT_ATOL = 1e-6
 _ROTATION_AXIS_MIN_ANGLE_RAD = math.radians(1.0)
 _ROTATION_AXIS_CONDITIONING_MIN_RATIO = 0.05
 _SAMPLE_ARCHIVE_MEMBERS = {
@@ -145,13 +146,17 @@ def _validate_rigid_transform(transform):
         rotation.T @ rotation,
         np.eye(3),
         rtol=0.0,
-        atol=_RIGID_TRANSFORM_ATOL,
+        atol=_RIGID_TRANSFORM_INPUT_ATOL,
     ):
         raise ValueError("transform rotation must be orthonormal")
     if not np.isclose(
-        np.linalg.det(rotation), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+        np.linalg.det(rotation), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_INPUT_ATOL
     ):
         raise ValueError("transform rotation determinant must be +1")
+
+    result = result.copy()
+    u, _, vt = np.linalg.svd(rotation)
+    result[:3, :3] = u @ vt
     return result
 
 

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -9,15 +9,52 @@ import math
 import numpy as np
 
 
+_RIGID_TRANSFORM_ATOL = 1e-9
+
+
+def _validate_rigid_transform(transform):
+    """Return a validated float64 homogeneous rigid transform."""
+    try:
+        result = np.asarray(transform, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("transform must be a numeric array with shape (4, 4)") from exc
+
+    if result.shape != (4, 4):
+        raise ValueError("transform must have shape (4, 4)")
+    if not np.all(np.isfinite(result)):
+        raise ValueError("transform must contain only finite values")
+    if not np.allclose(
+        result[3], [0.0, 0.0, 0.0, 1.0], rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+    ):
+        raise ValueError("transform bottom row must be [0, 0, 0, 1]")
+
+    rotation = result[:3, :3]
+    if not np.allclose(
+        rotation.T @ rotation,
+        np.eye(3),
+        rtol=0.0,
+        atol=_RIGID_TRANSFORM_ATOL,
+    ):
+        raise ValueError("transform rotation must be orthonormal")
+    if not np.isclose(
+        np.linalg.det(rotation), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+    ):
+        raise ValueError("transform rotation determinant must be +1")
+    return result
+
+
 def create_checkerboard_object_points(checkerboard, square_size_m):
     """Return planar checkerboard inner-corner coordinates in metres."""
     cols, rows = checkerboard
-    if cols <= 0 or rows <= 0 or square_size_m <= 0:
-        raise ValueError("Checkerboard dimensions and square size must be positive.")
+    square_size_m = float(square_size_m)
+    if cols <= 0 or rows <= 0 or not np.isfinite(square_size_m) or square_size_m <= 0:
+        raise ValueError(
+            "Checkerboard dimensions and square size must be finite and positive."
+        )
 
     points = np.zeros((cols * rows, 3), dtype=np.float64)
     points[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
-    points[:, :2] *= float(square_size_m)
+    points[:, :2] *= square_size_m
     return points
 
 
@@ -40,7 +77,7 @@ def pose6_to_matrix(pose):
 
 def matrix_to_pose6(transform):
     """Convert a homogeneous transform to a ZYX roll/pitch/yaw pose."""
-    T = np.asarray(transform, dtype=np.float64).reshape(4, 4)
+    T = _validate_rigid_transform(transform)
     pitch = math.asin(float(np.clip(-T[2, 0], -1.0, 1.0)))
 
     if abs(math.cos(pitch)) < 1e-9:
@@ -57,14 +94,14 @@ def matrix_to_pose6(transform):
 
 def transform_point(T_parent_child, point_child):
     """Map a 3D point from a child frame into its parent frame."""
-    transform = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    transform = _validate_rigid_transform(T_parent_child)
     point = np.asarray(point_child, dtype=np.float64).reshape(3)
     return (transform @ np.r_[point, 1.0])[:3]
 
 
 def invert_transform(T_parent_child):
     """Return the rigid inverse of a homogeneous transform."""
-    transform = np.asarray(T_parent_child, dtype=np.float64).reshape(4, 4)
+    transform = _validate_rigid_transform(T_parent_child)
     inverse = np.eye(4, dtype=np.float64)
     inverse[:3, :3] = transform[:3, :3].T
     inverse[:3, 3] = -inverse[:3, :3] @ transform[:3, 3]
@@ -88,11 +125,23 @@ def deproject_depth_pixel(
     if not np.isfinite(depth_scale_m) or depth_scale_m <= 0.0:
         raise ValueError("depth_scale_m must be finite and greater than zero")
 
+    min_depth_m = float(min_depth_m)
+    if not np.isfinite(min_depth_m) or min_depth_m < 0.0:
+        raise ValueError("min_depth_m must be finite and non-negative")
+    if max_depth_m is not None:
+        max_depth_m = float(max_depth_m)
+        if not np.isfinite(max_depth_m):
+            raise ValueError("max_depth_m must be finite")
+        if max_depth_m < min_depth_m:
+            raise ValueError(
+                "max_depth_m must be greater than or equal to min_depth_m"
+            )
+
     depth_m = depth_raw * depth_scale_m
     if not np.isfinite(depth_m) or depth_m <= 0.0:
         raise ValueError("depth must be finite and greater than zero")
-    if depth_m < float(min_depth_m) or (
-        max_depth_m is not None and depth_m > float(max_depth_m)
+    if depth_m < min_depth_m or (
+        max_depth_m is not None and depth_m > max_depth_m
     ):
         raise ValueError("depth is outside the configured range")
 
@@ -101,8 +150,16 @@ def deproject_depth_pixel(
     if not np.isfinite(fx) or not np.isfinite(fy) or fx <= 0.0 or fy <= 0.0:
         raise ValueError("camera focal lengths must be finite and positive")
 
-    x = (float(u) - float(intrinsics["cx"])) * depth_m / fx
-    y = (float(v) - float(intrinsics["cy"])) * depth_m / fy
+    u = float(u)
+    v = float(v)
+    cx = float(intrinsics["cx"])
+    cy = float(intrinsics["cy"])
+    for name, value in (("u", u), ("v", v), ("cx", cx), ("cy", cy)):
+        if not np.isfinite(value):
+            raise ValueError("{} must be finite".format(name))
+
+    x = (u - cx) * depth_m / fx
+    y = (v - cy) * depth_m / fy
     return np.array([x, y, depth_m], dtype=np.float64)
 
 

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -81,7 +81,14 @@ def deproject_depth_pixel(
     max_depth_m=None,
 ):
     """Deproject one raw depth pixel into the metric depth-camera frame."""
-    depth_m = float(depth_raw) * float(depth_scale_m)
+    depth_raw = float(depth_raw)
+    depth_scale_m = float(depth_scale_m)
+    if not np.isfinite(depth_raw) or depth_raw <= 0.0:
+        raise ValueError("depth_raw must be finite and greater than zero")
+    if not np.isfinite(depth_scale_m) or depth_scale_m <= 0.0:
+        raise ValueError("depth_scale_m must be finite and greater than zero")
+
+    depth_m = depth_raw * depth_scale_m
     if not np.isfinite(depth_m) or depth_m <= 0.0:
         raise ValueError("depth must be finite and greater than zero")
     if depth_m < float(min_depth_m) or (
@@ -91,8 +98,8 @@ def deproject_depth_pixel(
 
     fx = float(intrinsics["fx"])
     fy = float(intrinsics["fy"])
-    if fx <= 0.0 or fy <= 0.0:
-        raise ValueError("camera focal lengths must be positive")
+    if not np.isfinite(fx) or not np.isfinite(fy) or fx <= 0.0 or fy <= 0.0:
+        raise ValueError("camera focal lengths must be finite and positive")
 
     x = (float(u) - float(intrinsics["cx"])) * depth_m / fx
     y = (float(v) - float(intrinsics["cy"])) * depth_m / fy

--- a/pyAgxArm/demos/nero/orbbec_handeye_math.py
+++ b/pyAgxArm/demos/nero/orbbec_handeye_math.py
@@ -8,6 +8,7 @@ import json
 import math
 import zipfile
 from datetime import datetime, timezone
+from numbers import Integral, Real
 
 import numpy as np
 
@@ -140,9 +141,37 @@ def _validate_rigid_transform(transform):
 
 def create_checkerboard_object_points(checkerboard, square_size_m):
     """Return planar checkerboard inner-corner coordinates in metres."""
-    cols, rows = checkerboard
+    try:
+        dimensions = tuple(checkerboard)
+    except TypeError as exc:
+        raise ValueError(
+            "Checkerboard dimensions must contain exactly two finite positive integers."
+        ) from exc
+    if len(dimensions) != 2:
+        raise ValueError(
+            "Checkerboard dimensions must contain exactly two finite positive integers."
+        )
+
+    normalized_dimensions = []
+    for dimension in dimensions:
+        if isinstance(dimension, (bool, np.bool_)) or not isinstance(dimension, Real):
+            raise ValueError(
+                "Checkerboard dimensions must contain exactly two finite positive integers."
+            )
+        numeric_dimension = float(dimension)
+        if (
+            not np.isfinite(numeric_dimension)
+            or numeric_dimension <= 0.0
+            or not numeric_dimension.is_integer()
+        ):
+            raise ValueError(
+                "Checkerboard dimensions must contain exactly two finite positive integers."
+            )
+        normalized_dimensions.append(int(dimension))
+    cols, rows = normalized_dimensions
+
     square_size_m = float(square_size_m)
-    if cols <= 0 or rows <= 0 or not np.isfinite(square_size_m) or square_size_m <= 0:
+    if not np.isfinite(square_size_m) or square_size_m <= 0:
         raise ValueError(
             "Checkerboard dimensions and square size must be finite and positive."
         )

--- a/pyAgxArm/demos/nero/orbbec_v1_camera.py
+++ b/pyAgxArm/demos/nero/orbbec_v1_camera.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import hashlib
 import json
 import math
+import time
 
 import numpy as np
 
@@ -67,6 +68,10 @@ def normalize_d2c_transform(extrinsic):
         np.linalg.det(rotation), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
     ):
         raise ValueError("Orbbec depth-to-color rotation determinant must be +1")
+
+    # SDK v1 exposes float32 calibration; project its rounding error onto SO(3).
+    u, _, vt = np.linalg.svd(rotation)
+    rotation = u @ vt
 
     result = np.eye(4, dtype=np.float64)
     result[:3, :3] = rotation
@@ -294,9 +299,20 @@ def _select_device(devices, serial_number):
     return devices.get_device_by_index(0)
 
 
+def enable_frame_sync_if_supported(pipeline):
+    """Enable hardware frame sync when the selected camera supports it."""
+    try:
+        pipeline.enable_frame_sync()
+    except Exception as exc:
+        if "does not support frame sync" not in str(exc).lower():
+            raise
+        return False
+    return True
+
+
 @dataclass(frozen=True)
 class OrbbecFrames:
-    """A synchronized BGR color image and unscaled uint16 depth image."""
+    """A BGR color image and unscaled uint16 depth image from one frame set."""
 
     color_bgr: np.ndarray
     depth_raw: np.ndarray
@@ -314,7 +330,7 @@ class OrbbecV1Camera:
         color_width=1280,
         color_height=720,
         fps=30,
-        timeout_ms=100,
+        timeout_ms=1000,
     ):
         self.serial_number = serial_number
         self.color_width = int(color_width)
@@ -386,7 +402,7 @@ class OrbbecV1Camera:
             config.enable_stream(color_stream)
             config.enable_stream(depth_stream)
             config.set_align_mode(sdk.OBAlignMode.DISABLE)
-            pipeline.enable_frame_sync()
+            enable_frame_sync_if_supported(pipeline)
             pipeline.start(config)
             camera_param = pipeline.get_camera_param()
             device_info = device.get_device_info()
@@ -415,27 +431,38 @@ class OrbbecV1Camera:
         return self
 
     def wait_for_frames(self):
-        """Wait for synchronized frames and convert them to calibration inputs."""
+        """Wait for a complete color and depth frame set before converting it."""
         if not self._started or self._pipeline is None:
             raise RuntimeError("Orbbec camera has not been started")
 
-        frameset = self._pipeline.wait_for_frames(self.timeout_ms)
-        if frameset is None:
-            raise RuntimeError(
-                "Timed out waiting for Orbbec frames after {} ms".format(
-                    self.timeout_ms
-                )
-            )
-        color_frame = frameset.get_color_frame()
-        depth_frame = frameset.get_depth_frame()
-        if color_frame is None or depth_frame is None:
+        deadline = time.monotonic() + self.timeout_ms / 1000.0
+        color_frame = None
+        depth_frame = None
+        missing = None
+        while time.monotonic() < deadline:
+            remaining_ms = max(1, int(math.ceil((deadline - time.monotonic()) * 1000.0)))
+            frameset = self._pipeline.wait_for_frames(remaining_ms)
+            if frameset is None:
+                break
+            color_frame = frameset.get_color_frame()
+            depth_frame = frameset.get_depth_frame()
+            if color_frame is not None and depth_frame is not None:
+                break
             missing = []
             if color_frame is None:
                 missing.append("color")
             if depth_frame is None:
                 missing.append("depth")
+
+        if color_frame is None or depth_frame is None:
+            detail = ""
+            if missing:
+                detail = "; last frame set was missing {} frame".format(
+                    " and ".join(missing)
+                )
             raise RuntimeError(
-                "Orbbec frame set is missing {} frame".format(" and ".join(missing))
+                "Timed out waiting for complete Orbbec color and depth frames after {} ms{}"
+                .format(self.timeout_ms, detail)
             )
 
         import cv2

--- a/pyAgxArm/demos/nero/orbbec_v1_camera.py
+++ b/pyAgxArm/demos/nero/orbbec_v1_camera.py
@@ -235,12 +235,22 @@ def depth_frame_to_array(frame):
     height = int(frame.get_height())
     data = frame.get_data()
     try:
-        if isinstance(data, np.ndarray):
-            values = np.asarray(data, dtype=np.uint8).reshape(-1).view(np.uint16)
+        array = np.asarray(data)
+        if array.dtype == np.uint16:
+            values = np.ascontiguousarray(array).reshape(-1).copy()
+        elif array.dtype == np.uint8:
+            byte_data = np.ascontiguousarray(array).reshape(-1)
+            values = np.frombuffer(byte_data.tobytes(), dtype=np.uint16)
         else:
             values = np.frombuffer(data, dtype=np.uint16)
+        if values.size != width * height:
+            raise ValueError(
+                "expected {} uint16 pixels, received {}".format(
+                    width * height, values.size
+                )
+            )
         return values.reshape(height, width)
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         raise RuntimeError(
             "Invalid Orbbec depth frame buffer for {}x{}".format(width, height)
         ) from exc

--- a/pyAgxArm/demos/nero/orbbec_v1_camera.py
+++ b/pyAgxArm/demos/nero/orbbec_v1_camera.py
@@ -10,6 +10,7 @@ import numpy as np
 
 
 _DOCS_PATH = "docs/nero/orbbec_dabai_handeye.md"
+_SDK_SOURCE_URL = "https://github.com/orbbec/pyorbbecsdk/tree/main"
 _RIGID_TRANSFORM_ATOL = 1e-6
 
 
@@ -19,7 +20,8 @@ def require_orbbec_sdk():
         import pyorbbecsdk
     except ImportError as exc:
         raise RuntimeError(
-            "Orbbec SDK v1 is required. Follow {}.".format(_DOCS_PATH)
+            "Orbbec SDK v1 module 'pyorbbecsdk' is required. Follow {} or install "
+            "the official v1 source from {}.".format(_DOCS_PATH, _SDK_SOURCE_URL)
         ) from exc
     return pyorbbecsdk
 
@@ -338,11 +340,26 @@ class OrbbecV1Camera:
             return None
         return copy.deepcopy(self._metadata)
 
+    def _clear_run_state(self):
+        """Discard state that must not survive a new pipeline start."""
+        self._context = None
+        self._pipeline = None
+        self._sdk = None
+        self._camera_param = None
+        self._device_info = None
+        self._metadata = None
+        self._started = False
+        self.color_profile = None
+        self.depth_profile = None
+        self.color_profile_used_fallback = None
+        self.depth_profile_used_fallback = None
+
     def start(self):
         """Configure and start the v1 pipeline with unaligned raw depth."""
         if self._started:
             return self
 
+        self._clear_run_state()
         pipeline = None
         try:
             sdk = require_orbbec_sdk()
@@ -379,6 +396,7 @@ class OrbbecV1Camera:
                     pipeline.stop()
                 except Exception:
                     pass
+            self._clear_run_state()
             raise RuntimeError(
                 "Failed to start Orbbec camera: {}. Check connection, serial, and SDK setup."
                 .format(exc)
@@ -444,6 +462,10 @@ class OrbbecV1Camera:
         """Stop the pipeline once; repeated calls are harmless."""
         pipeline = self._pipeline
         self._pipeline = None
+        self._context = None
+        self._sdk = None
+        self._camera_param = None
+        self._device_info = None
         self._started = False
         if pipeline is not None:
             pipeline.stop()

--- a/pyAgxArm/demos/nero/orbbec_v1_camera.py
+++ b/pyAgxArm/demos/nero/orbbec_v1_camera.py
@@ -1,0 +1,446 @@
+"""Lazy Orbbec SDK v1 camera adapter for DaBai hand-eye calibration."""
+
+import copy
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+
+import numpy as np
+
+
+_DOCS_PATH = "docs/nero/orbbec_dabai_handeye.md"
+_RIGID_TRANSFORM_ATOL = 1e-6
+
+
+def require_orbbec_sdk():
+    """Import the optional Orbbec SDK only when camera access is requested."""
+    try:
+        import pyorbbecsdk
+    except ImportError as exc:
+        raise RuntimeError(
+            "Orbbec SDK v1 is required. Follow {}.".format(_DOCS_PATH)
+        ) from exc
+    return pyorbbecsdk
+
+
+def normalize_intrinsic(intrinsic):
+    """Convert v1 camera intrinsics to the local metadata schema."""
+    return {
+        "width": int(intrinsic.width),
+        "height": int(intrinsic.height),
+        "fx": float(intrinsic.fx),
+        "fy": float(intrinsic.fy),
+        "cx": float(intrinsic.cx),
+        "cy": float(intrinsic.cy),
+    }
+
+
+def normalize_distortion(distortion):
+    """Return v1 distortion coefficients in OpenCV order."""
+    return [
+        float(getattr(distortion, name))
+        for name in ("k1", "k2", "p1", "p2", "k3", "k4", "k5", "k6")
+    ]
+
+
+def normalize_d2c_transform(extrinsic):
+    """Return the v1 depth-to-color transform with metre translation."""
+    try:
+        rotation = np.asarray(extrinsic.rot, dtype=np.float64).reshape(3, 3)
+        translation_mm = np.asarray(extrinsic.transform, dtype=np.float64).reshape(3)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("Orbbec depth-to-color transform must contain 9 rotation and 3 translation values") from exc
+
+    if not np.all(np.isfinite(rotation)) or not np.all(np.isfinite(translation_mm)):
+        raise ValueError("Orbbec depth-to-color transform must contain only finite values")
+    if not np.allclose(
+        rotation.T @ rotation,
+        np.eye(3),
+        rtol=0.0,
+        atol=_RIGID_TRANSFORM_ATOL,
+    ):
+        raise ValueError("Orbbec depth-to-color rotation must be orthonormal")
+    if not np.isclose(
+        np.linalg.det(rotation), 1.0, rtol=0.0, atol=_RIGID_TRANSFORM_ATOL
+    ):
+        raise ValueError("Orbbec depth-to-color rotation determinant must be +1")
+
+    result = np.eye(4, dtype=np.float64)
+    result[:3, :3] = rotation
+    result[:3, 3] = translation_mm / 1000.0
+    return result
+
+
+def depth_scale_mm_to_m(scale):
+    """Convert the SDK depth-unit scale from millimetres to metres."""
+    value = float(scale)
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError("Orbbec depth scale must be finite and positive")
+    return value / 1000.0
+
+
+def select_video_profile(profile_list, width, height, fps, formats):
+    """Select the first requested color profile, with an explicit fallback."""
+    last_error = None
+    for image_format in formats:
+        try:
+            profile = profile_list.get_video_stream_profile(
+                width, height, image_format, fps
+            )
+        except Exception as exc:
+            last_error = exc
+            continue
+        if profile is not None:
+            return profile, False
+
+    try:
+        profile = profile_list.get_default_video_stream_profile()
+    except Exception as exc:
+        raise RuntimeError(
+            "No requested Orbbec video profile is available and the default profile could not be selected"
+        ) from exc
+    if profile is None:
+        raise RuntimeError(
+            "No requested Orbbec video profile is available and the SDK returned no default profile"
+        ) from last_error
+    return profile, True
+
+
+def select_default_depth_profile(profile_list):
+    """Select the SDK's explicit default depth profile."""
+    try:
+        profile = profile_list.get_default_video_stream_profile()
+    except Exception as exc:
+        raise RuntimeError("Unable to select the default Orbbec depth profile") from exc
+    if profile is None:
+        raise RuntimeError("The SDK returned no default Orbbec depth profile")
+    return profile, True
+
+
+def profile_to_string(profile):
+    """Return the exact resolution, rate, and format used by a stream profile."""
+    image_format = profile.get_format()
+    format_name = getattr(image_format, "name", None)
+    if callable(format_name):
+        format_name = format_name()
+    if format_name is None:
+        format_name = str(image_format)
+    return "{}x{}@{}_{}".format(
+        int(profile.get_width()),
+        int(profile.get_height()),
+        int(profile.get_fps()),
+        format_name,
+    )
+
+
+def camera_fingerprint(serial, color_profile, depth_profile):
+    """Return a stable identifier for a device and its selected stream profiles."""
+    payload = json.dumps(
+        [str(serial), str(color_profile), str(depth_profile)],
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_camera_metadata(
+    camera_param, device_info, color_profile, depth_profile, depth_scale_mm
+):
+    """Normalize v1 calibration and device information for persisted samples."""
+    T_color_depth = normalize_d2c_transform(camera_param.transform)
+    serial = str(device_info.get_serial_number())
+    return {
+        "name": str(device_info.get_name()),
+        "serial": serial,
+        "firmware": str(device_info.get_firmware_version()),
+        "color_profile": str(color_profile),
+        "depth_profile": str(depth_profile),
+        "color_intrinsics": normalize_intrinsic(camera_param.rgb_intrinsic),
+        "depth_intrinsics": normalize_intrinsic(camera_param.depth_intrinsic),
+        "color_distortion": normalize_distortion(camera_param.rgb_distortion),
+        "depth_distortion": normalize_distortion(camera_param.depth_distortion),
+        "depth_scale_m": depth_scale_mm_to_m(depth_scale_mm),
+        "T_color_depth_matrix": T_color_depth.reshape(-1).tolist(),
+        "camera_fingerprint": camera_fingerprint(
+            serial, color_profile, depth_profile
+        ),
+    }
+
+
+def _frame_bytes(frame):
+    """Return the SDK frame payload as a one-dimensional uint8 view."""
+    data = frame.get_data()
+    if isinstance(data, np.ndarray):
+        return np.asarray(data, dtype=np.uint8).reshape(-1)
+    return np.frombuffer(data, dtype=np.uint8)
+
+
+def frame_to_bgr_image(frame, sdk, cv2_module):
+    """Convert supported SDK v1 color frames to a BGR OpenCV image."""
+    width = int(frame.get_width())
+    height = int(frame.get_height())
+    image_format = frame.get_format()
+    formats = sdk.OBFormat
+    data = _frame_bytes(frame)
+
+    try:
+        if image_format == formats.RGB:
+            return cv2_module.cvtColor(
+                data.reshape(height, width, 3), cv2_module.COLOR_RGB2BGR
+            )
+        if image_format == formats.BGR:
+            return data.reshape(height, width, 3)
+        if image_format == formats.MJPG:
+            image = cv2_module.imdecode(data, cv2_module.IMREAD_COLOR)
+            if image is None:
+                raise RuntimeError("Unable to decode Orbbec MJPG color frame")
+            return image
+        if image_format == formats.YUYV:
+            return cv2_module.cvtColor(
+                data.reshape(height, width, 2), cv2_module.COLOR_YUV2BGR_YUY2
+            )
+        if image_format == formats.UYVY:
+            return cv2_module.cvtColor(
+                data.reshape(height, width, 2), cv2_module.COLOR_YUV2BGR_UYVY
+            )
+        if image_format == formats.I420:
+            return cv2_module.cvtColor(
+                data.reshape(height * 3 // 2, width),
+                cv2_module.COLOR_YUV2BGR_I420,
+            )
+        if image_format == formats.NV12:
+            return cv2_module.cvtColor(
+                data.reshape(height * 3 // 2, width),
+                cv2_module.COLOR_YUV2BGR_NV12,
+            )
+        if image_format == formats.NV21:
+            return cv2_module.cvtColor(
+                data.reshape(height * 3 // 2, width),
+                cv2_module.COLOR_YUV2BGR_NV21,
+            )
+    except ValueError as exc:
+        raise RuntimeError(
+            "Invalid Orbbec color frame buffer for {}x{} {}".format(
+                width, height, image_format
+            )
+        ) from exc
+
+    raise RuntimeError("Unsupported Orbbec color format: {}".format(image_format))
+
+
+def depth_frame_to_array(frame):
+    """Return the v1 depth frame as an unscaled uint16 image."""
+    width = int(frame.get_width())
+    height = int(frame.get_height())
+    data = frame.get_data()
+    try:
+        if isinstance(data, np.ndarray):
+            values = np.asarray(data, dtype=np.uint8).reshape(-1).view(np.uint16)
+        else:
+            values = np.frombuffer(data, dtype=np.uint16)
+        return values.reshape(height, width)
+    except ValueError as exc:
+        raise RuntimeError(
+            "Invalid Orbbec depth frame buffer for {}x{}".format(width, height)
+        ) from exc
+
+
+def _device_count(devices):
+    """Return the v1 device-list count across supported binding variants."""
+    get_count = getattr(devices, "get_count", None)
+    if get_count is not None:
+        return int(get_count())
+    return len(devices)
+
+
+def _select_device(devices, serial_number):
+    """Select an explicitly requested device or the sole connected device."""
+    count = _device_count(devices)
+    if serial_number is not None:
+        try:
+            device = devices.get_device_by_serial_number(serial_number)
+        except Exception as exc:
+            raise RuntimeError(
+                "Unable to select Orbbec device with serial {!r}".format(
+                    serial_number
+                )
+            ) from exc
+        if device is None:
+            raise RuntimeError(
+                "No Orbbec device found with serial {!r}".format(serial_number)
+            )
+        return device
+
+    if count == 0:
+        raise RuntimeError("No Orbbec devices were detected")
+    if count != 1:
+        raise RuntimeError(
+            "Expected exactly one Orbbec device when serial_number is omitted; found {}"
+            .format(count)
+        )
+    return devices.get_device_by_index(0)
+
+
+@dataclass(frozen=True)
+class OrbbecFrames:
+    """A synchronized BGR color image and unscaled uint16 depth image."""
+
+    color_bgr: np.ndarray
+    depth_raw: np.ndarray
+    depth_scale_m: float
+    color_timestamp_ms: float
+    depth_timestamp_ms: float
+
+
+class OrbbecV1Camera:
+    """Own an Orbbec SDK v1 pipeline for raw color and depth acquisition."""
+
+    def __init__(
+        self,
+        serial_number=None,
+        color_width=1280,
+        color_height=720,
+        fps=30,
+        timeout_ms=100,
+    ):
+        self.serial_number = serial_number
+        self.color_width = int(color_width)
+        self.color_height = int(color_height)
+        self.fps = int(fps)
+        self.timeout_ms = int(timeout_ms)
+        self._context = None
+        self._pipeline = None
+        self._sdk = None
+        self._camera_param = None
+        self._device_info = None
+        self._metadata = None
+        self._started = False
+        self.color_profile = None
+        self.depth_profile = None
+        self.color_profile_used_fallback = None
+        self.depth_profile_used_fallback = None
+
+    @property
+    def metadata(self):
+        """Return a mutable copy of first-frame camera metadata, if available."""
+        if self._metadata is None:
+            return None
+        return copy.deepcopy(self._metadata)
+
+    def start(self):
+        """Configure and start the v1 pipeline with unaligned raw depth."""
+        if self._started:
+            return self
+
+        pipeline = None
+        try:
+            sdk = require_orbbec_sdk()
+            context = sdk.Context()
+            device = _select_device(context.query_devices(), self.serial_number)
+            pipeline = sdk.Pipeline(device)
+            config = sdk.Config()
+            color_profiles = pipeline.get_stream_profile_list(
+                sdk.OBSensorType.COLOR_SENSOR
+            )
+            color_stream, color_fallback = select_video_profile(
+                color_profiles,
+                self.color_width,
+                self.color_height,
+                self.fps,
+                (sdk.OBFormat.RGB, sdk.OBFormat.MJPG, sdk.OBFormat.YUYV),
+            )
+            depth_profiles = pipeline.get_stream_profile_list(
+                sdk.OBSensorType.DEPTH_SENSOR
+            )
+            depth_stream, depth_fallback = select_default_depth_profile(
+                depth_profiles
+            )
+            config.enable_stream(color_stream)
+            config.enable_stream(depth_stream)
+            config.set_align_mode(sdk.OBAlignMode.DISABLE)
+            pipeline.enable_frame_sync()
+            pipeline.start(config)
+            camera_param = pipeline.get_camera_param()
+            device_info = device.get_device_info()
+        except Exception as exc:
+            if pipeline is not None:
+                try:
+                    pipeline.stop()
+                except Exception:
+                    pass
+            raise RuntimeError(
+                "Failed to start Orbbec camera: {}. Check connection, serial, and SDK setup."
+                .format(exc)
+            ) from exc
+
+        self._sdk = sdk
+        self._context = context
+        self._pipeline = pipeline
+        self._camera_param = camera_param
+        self._device_info = device_info
+        self.color_profile = profile_to_string(color_stream)
+        self.depth_profile = profile_to_string(depth_stream)
+        self.color_profile_used_fallback = color_fallback
+        self.depth_profile_used_fallback = depth_fallback
+        self._started = True
+        return self
+
+    def wait_for_frames(self):
+        """Wait for synchronized frames and convert them to calibration inputs."""
+        if not self._started or self._pipeline is None:
+            raise RuntimeError("Orbbec camera has not been started")
+
+        frameset = self._pipeline.wait_for_frames(self.timeout_ms)
+        if frameset is None:
+            raise RuntimeError(
+                "Timed out waiting for Orbbec frames after {} ms".format(
+                    self.timeout_ms
+                )
+            )
+        color_frame = frameset.get_color_frame()
+        depth_frame = frameset.get_depth_frame()
+        if color_frame is None or depth_frame is None:
+            missing = []
+            if color_frame is None:
+                missing.append("color")
+            if depth_frame is None:
+                missing.append("depth")
+            raise RuntimeError(
+                "Orbbec frame set is missing {} frame".format(" and ".join(missing))
+            )
+
+        import cv2
+
+        depth_scale_mm = depth_frame.get_depth_scale()
+        result = OrbbecFrames(
+            color_bgr=frame_to_bgr_image(color_frame, self._sdk, cv2),
+            depth_raw=depth_frame_to_array(depth_frame),
+            depth_scale_m=depth_scale_mm_to_m(depth_scale_mm),
+            color_timestamp_ms=color_frame.get_timestamp(),
+            depth_timestamp_ms=depth_frame.get_timestamp(),
+        )
+        if self._metadata is None:
+            self._metadata = build_camera_metadata(
+                self._camera_param,
+                self._device_info,
+                self.color_profile,
+                self.depth_profile,
+                depth_scale_mm,
+            )
+        return result
+
+    def stop(self):
+        """Stop the pipeline once; repeated calls are harmless."""
+        pipeline = self._pipeline
+        self._pipeline = None
+        self._started = False
+        if pipeline is not None:
+            pipeline.stop()
+
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+        return False

--- a/tests/test_orbbec_handeye_cli.py
+++ b/tests/test_orbbec_handeye_cli.py
@@ -1,0 +1,244 @@
+"""Hardware-free tests for the interactive Orbbec hand-eye CLI."""
+
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pytest
+
+
+NERO_DEMO_DIR = Path(__file__).resolve().parents[1] / "pyAgxArm" / "demos" / "nero"
+sys.path.insert(0, str(NERO_DEMO_DIR))
+
+import orbbec_handeye_calib as cli  # noqa: E402
+
+
+def _metadata(fingerprint="camera-1"):
+    return {
+        "camera_fingerprint": fingerprint,
+        "color_profile": "1280x720@30_RGB",
+        "depth_profile": "640x576@30_Y16",
+        "color_intrinsics": {
+            "width": 1280,
+            "height": 720,
+            "fx": 900.0,
+            "fy": 901.0,
+            "cx": 640.0,
+            "cy": 360.0,
+        },
+        "color_distortion": [0.1, -0.1, 0.0, 0.0, 0.01],
+        "depth_scale_m": 0.001,
+        "T_color_depth_matrix": np.eye(4).reshape(-1).tolist(),
+    }
+
+
+def _detection():
+    return (
+        True,
+        np.array([[0.1], [0.2], [0.3]], dtype=np.float64),
+        np.array([[0.4], [0.5], [0.6]], dtype=np.float64),
+        np.zeros((70, 1, 2), dtype=np.float32),
+    )
+
+
+def _sample(timestamp=1.0):
+    return {
+        "flange_pose": [0.0] * 6,
+        "target_rvec": np.zeros((3, 1), dtype=np.float64),
+        "target_tvec": np.array([[0.0], [0.0], [1.0]], dtype=np.float64),
+        "timestamp": timestamp,
+    }
+
+
+def test_parser_defaults_and_handeye_method_choices():
+    args = cli.build_arg_parser().parse_args([])
+
+    assert (args.checkerboard_cols, args.checkerboard_rows, args.square_size) == (
+        10,
+        7,
+        0.02,
+    )
+    assert args.samples == Path("orbbec_handeye_samples.npz")
+    assert args.output == Path("orbbec_handeye_result.json")
+    assert args.method == "TSAI"
+    assert (args.width, args.height, args.fps) == (1280, 720, 30)
+    with pytest.raises(SystemExit):
+        cli.build_arg_parser().parse_args(["--method", "NOPE"])
+
+
+def test_import_and_help_do_not_load_optional_sdk_or_robot(monkeypatch, capsys):
+    real_import = __import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name in {"pyorbbecsdk", "pyAgxArm"}:
+            raise AssertionError("optional dependency imported eagerly: {}".format(name))
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    sys.modules.pop("orbbec_handeye_calib", None)
+    module = importlib.import_module("orbbec_handeye_calib")
+
+    with pytest.raises(SystemExit) as exc:
+        module.main(["--help"])
+    assert exc.value.code == 0
+    assert "--calibrate-only" in capsys.readouterr().out
+
+
+def test_capture_sample_requires_current_valid_detection_and_normalizes_values():
+    with pytest.raises(ValueError, match="current"):
+        cli.capture_sample(None, [0.0] * 6, 1.0)
+
+    sample = cli.capture_sample(_detection(), np.arange(6), 4.5)
+
+    assert sample["flange_pose"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert sample["target_rvec"].shape == (3, 1)
+    assert sample["target_tvec"].shape == (3, 1)
+    assert sample["timestamp"] == 4.5
+
+
+def test_get_flange_pose6_validates_exactly_six_finite_numbers():
+    robot = SimpleNamespace(
+        get_flange_pose=lambda: SimpleNamespace(msg=[1, 2, 3, 4, 5, 6])
+    )
+    assert cli.get_flange_pose6(robot) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+    for pose in ([1, 2], [1, 2, 3, 4, 5, float("nan")]):
+        robot = SimpleNamespace(get_flange_pose=lambda pose=pose: SimpleNamespace(msg=pose))
+        with pytest.raises(RuntimeError, match="six finite"):
+            cli.get_flange_pose6(robot)
+
+
+def test_camera_matrix_and_distortion_normalize_valid_metadata():
+    matrix, distortion = cli.camera_matrix_and_distortion(_metadata())
+
+    np.testing.assert_allclose(
+        matrix, [[900.0, 0.0, 640.0], [0.0, 901.0, 360.0], [0.0, 0.0, 1.0]]
+    )
+    assert distortion.shape in {(5,), (5, 1)}
+    with pytest.raises(ValueError):
+        cli.camera_matrix_and_distortion({})
+    invalid = _metadata()
+    invalid["color_distortion"] = [[0.0, 0.0], [0.0, 0.0]]
+    with pytest.raises(ValueError, match="distortion"):
+        cli.camera_matrix_and_distortion(invalid)
+
+
+def test_detect_checkerboard_pose_returns_current_pnp_solution():
+    checkerboard = (10, 7)
+    square_px = 48
+    image = np.full((8 * square_px + 50, 11 * square_px + 50, 3), 255, dtype=np.uint8)
+    for row in range(8):
+        for col in range(11):
+            if (row + col) % 2:
+                cv2.rectangle(
+                    image,
+                    (25 + col * square_px, 25 + row * square_px),
+                    (25 + (col + 1) * square_px, 25 + (row + 1) * square_px),
+                    (0, 0, 0),
+                    -1,
+                )
+    matrix = np.array([[1000.0, 0.0, image.shape[1] / 2], [0.0, 1000.0, image.shape[0] / 2], [0.0, 0.0, 1.0]])
+
+    ok, rvec, tvec, corners = cli.detect_checkerboard_pose(
+        image, matrix, np.zeros(5), checkerboard, 0.02
+    )
+
+    assert ok is True
+    assert corners.shape[0] == 70
+    assert np.all(np.isfinite(rvec))
+    assert float(tvec[2]) > 0.0
+
+
+def test_failed_detection_returns_no_stale_pose():
+    image = np.full((320, 320, 3), 127, dtype=np.uint8)
+    ok, rvec, tvec, corners = cli.detect_checkerboard_pose(
+        image, np.eye(3), np.zeros(5), (10, 7), 0.02
+    )
+
+    assert (ok, rvec, tvec, corners) == (False, None, None, None)
+
+
+def test_json_writer_creates_parent_and_rejects_non_finite_values(tmp_path):
+    destination = tmp_path / "results" / "result.json"
+    cli.write_result_json(destination, {"value": 1.0})
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"value": 1.0}
+    with pytest.raises(ValueError, match="finite"):
+        cli.write_result_json(destination, {"value": float("nan")})
+
+
+def test_calibrate_only_uses_persisted_metadata_without_hardware(tmp_path, monkeypatch):
+    sample_path = tmp_path / "samples.npz"
+    output_path = tmp_path / "result.json"
+    captured = {}
+
+    monkeypatch.setattr(cli, "load_samples", lambda path: ([_sample()], _metadata()))
+    monkeypatch.setattr(
+        cli,
+        "calibrate_eye_in_hand",
+        lambda samples, transform, metadata, **kwargs: captured.update(
+            samples=samples, transform=transform, metadata=metadata, kwargs=kwargs
+        )
+        or {"result": "ok"},
+    )
+    monkeypatch.setattr(cli, "create_nero_robot", lambda args: pytest.fail("robot used"))
+    monkeypatch.setattr(cli, "create_camera", lambda args: pytest.fail("camera used"))
+
+    assert cli.main(["--calibrate-only", "--samples", str(sample_path), "--output", str(output_path)]) == 0
+    assert captured["metadata"]["camera_fingerprint"] == "camera-1"
+    np.testing.assert_allclose(captured["transform"], np.eye(4))
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {"result": "ok"}
+
+
+def test_collection_key_handler_rejects_stale_detection_and_preserves_metadata(tmp_path, monkeypatch):
+    calls = []
+    metadata = _metadata()
+    robot = SimpleNamespace(get_flange_pose=lambda: SimpleNamespace(msg=[0] * 6))
+    args = cli.build_arg_parser().parse_args(["--samples", str(tmp_path / "samples.npz")])
+
+    monkeypatch.setattr(cli, "save_samples", lambda path, samples, saved_metadata: calls.append((path, samples, saved_metadata)))
+
+    assert cli.handle_collection_key(ord("s"), None, robot, [], metadata, args) is False
+    samples = []
+    assert cli.handle_collection_key(ord("s"), _detection(), robot, samples, metadata, args) is True
+    assert len(samples) == 1
+    assert calls[0][2] == metadata
+    assert cli.handle_collection_key(ord("q"), _detection(), robot, samples, metadata, args) is False
+
+
+def test_collection_cleanup_runs_when_frame_processing_raises(monkeypatch):
+    events = []
+
+    class Camera:
+        metadata = _metadata()
+        color_profile = "1280x720@30_RGB"
+        depth_profile = "640x576@30_Y16"
+
+        def start(self):
+            events.append("start")
+            return self
+
+        def wait_for_frames(self):
+            return SimpleNamespace(color_bgr=np.zeros((20, 20, 3), dtype=np.uint8))
+
+        def stop(self):
+            events.append("stop")
+
+    robot = SimpleNamespace(disconnect=lambda: events.append("disconnect"))
+    monkeypatch.setattr(cli, "create_camera", lambda args: Camera())
+    monkeypatch.setattr(cli, "create_nero_robot", lambda args: robot)
+    monkeypatch.setattr(cli, "load_existing_samples", lambda *args: [])
+    monkeypatch.setattr(cli, "destroy_windows", lambda: events.append("windows"))
+    monkeypatch.setattr(
+        cli,
+        "run_frame_loop",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("frame failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="frame failure"):
+        cli.run_collection(cli.build_arg_parser().parse_args([]))
+    assert events == ["start", "disconnect", "stop", "windows"]

--- a/tests/test_orbbec_handeye_cli.py
+++ b/tests/test_orbbec_handeye_cli.py
@@ -202,7 +202,7 @@ def test_detect_checkerboard_pose_returns_current_pnp_solution():
     assert ok is True
     assert corners.shape[0] == 70
     assert np.all(np.isfinite(rvec))
-    assert float(tvec[2]) > 0.0
+    assert float(tvec[2, 0]) > 0.0
 
 
 def test_failed_detection_returns_no_stale_pose():

--- a/tests/test_orbbec_handeye_cli.py
+++ b/tests/test_orbbec_handeye_cli.py
@@ -36,6 +36,15 @@ def _metadata(fingerprint="camera-1"):
     }
 
 
+def _collection_metadata(checkerboard=(10, 7), square_size_m=0.02):
+    metadata = _metadata()
+    metadata["checkerboard"] = {
+        "inner_corners": list(checkerboard),
+        "square_size_m": square_size_m,
+    }
+    return metadata
+
+
 def _detection():
     return (
         True,
@@ -68,6 +77,49 @@ def test_parser_defaults_and_handeye_method_choices():
     assert (args.width, args.height, args.fps) == (1280, 720, 30)
     with pytest.raises(SystemExit):
         cli.build_arg_parser().parse_args(["--method", "NOPE"])
+
+
+def test_normalize_samples_path_appends_npz_and_rejects_other_suffixes():
+    assert cli.normalize_samples_path(Path("captures/handeye")) == Path(
+        "captures/handeye.npz"
+    )
+    assert cli.normalize_samples_path(Path("captures/handeye.npz")) == Path(
+        "captures/handeye.npz"
+    )
+    with pytest.raises(ValueError, match="must use .npz"):
+        cli.normalize_samples_path(Path("captures/handeye.json"))
+
+
+def test_validate_checkerboard_args_rejects_non_positive_values():
+    args = cli.build_arg_parser().parse_args(
+        ["--checkerboard-cols", "0", "--square-size", "nan"]
+    )
+
+    with pytest.raises(ValueError, match="Checkerboard dimensions"):
+        cli.validate_checkerboard_args(args)
+
+
+def test_validate_checkerboard_args_rejects_non_finite_integer_conversion():
+    args = cli.build_arg_parser().parse_args(["--checkerboard-cols", "1" + "0" * 400])
+
+    with pytest.raises(ValueError, match="Checkerboard dimensions"):
+        cli.validate_checkerboard_args(args)
+
+
+def test_collection_metadata_preserves_camera_data_and_records_geometry():
+    camera_metadata = _metadata()
+    args = cli.build_arg_parser().parse_args(
+        ["--checkerboard-cols", "8", "--checkerboard-rows", "6", "--square-size", "0.015"]
+    )
+
+    metadata = cli.collection_metadata(camera_metadata, args)
+
+    assert metadata["camera_fingerprint"] == "camera-1"
+    assert metadata["checkerboard"] == {
+        "inner_corners": [8, 6],
+        "square_size_m": 0.015,
+    }
+    assert "checkerboard" not in camera_metadata
 
 
 def test_import_and_help_do_not_load_optional_sdk_or_robot(monkeypatch, capsys):
@@ -176,7 +228,9 @@ def test_calibrate_only_uses_persisted_metadata_without_hardware(tmp_path, monke
     output_path = tmp_path / "result.json"
     captured = {}
 
-    monkeypatch.setattr(cli, "load_samples", lambda path: ([_sample()], _metadata()))
+    monkeypatch.setattr(
+        cli, "load_samples", lambda path: ([_sample()], _collection_metadata())
+    )
     monkeypatch.setattr(
         cli,
         "calibrate_eye_in_hand",
@@ -192,6 +246,86 @@ def test_calibrate_only_uses_persisted_metadata_without_hardware(tmp_path, monke
     assert captured["metadata"]["camera_fingerprint"] == "camera-1"
     np.testing.assert_allclose(captured["transform"], np.eye(4))
     assert json.loads(output_path.read_text(encoding="utf-8")) == {"result": "ok"}
+
+
+def test_calibrate_only_uses_saved_nondefault_checkerboard_geometry(tmp_path, monkeypatch):
+    captured = {}
+    metadata = _collection_metadata((8, 6), 0.015)
+    monkeypatch.setattr(cli, "load_samples", lambda path: ([_sample()], metadata))
+    monkeypatch.setattr(
+        cli,
+        "calibrate_eye_in_hand",
+        lambda samples, transform, camera_metadata, **kwargs: captured.update(kwargs)
+        or {"result": "ok"},
+    )
+
+    assert cli.main(
+        ["--calibrate-only", "--samples", str(tmp_path / "samples"), "--output", str(tmp_path / "result.json")]
+    ) == 0
+    assert captured["checkerboard"] == (8, 6)
+    assert captured["square_size_m"] == 0.015
+
+
+@pytest.mark.parametrize(
+    "stored_metadata",
+    [
+        _metadata(),
+        dict(_metadata(), checkerboard={"inner_corners": [8], "square_size_m": 0.02}),
+        dict(_metadata(), checkerboard={"inner_corners": [8, 6], "square_size_m": 0.0}),
+        dict(
+            _metadata(),
+            checkerboard={"inner_corners": [10 ** 400, 6], "square_size_m": 0.02},
+        ),
+    ],
+)
+def test_calibrate_only_rejects_missing_or_malformed_stored_geometry(
+    tmp_path, monkeypatch, stored_metadata
+):
+    monkeypatch.setattr(cli, "load_samples", lambda path: ([_sample()], stored_metadata))
+
+    with pytest.raises(ValueError, match="stored checkerboard geometry"):
+        cli.main(["--calibrate-only", "--samples", str(tmp_path / "samples")])
+
+
+def test_main_normalizes_samples_path_before_calibrate_only_load(tmp_path, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        cli,
+        "load_samples",
+        lambda path: captured.update(path=path) or ([_sample()], _collection_metadata()),
+    )
+    monkeypatch.setattr(cli, "calibrate_eye_in_hand", lambda *args, **kwargs: {"result": "ok"})
+
+    assert cli.main(
+        [
+            "--calibrate-only",
+            "--samples",
+            str(tmp_path / "samples"),
+            "--output",
+            str(tmp_path / "result.json"),
+        ]
+    ) == 0
+    assert captured["path"] == tmp_path / "samples.npz"
+
+
+def test_main_rejects_non_npz_samples_path_before_loading(monkeypatch):
+    monkeypatch.setattr(cli, "load_samples", lambda path: pytest.fail("samples loaded"))
+
+    with pytest.raises(ValueError, match="must use .npz"):
+        cli.main(["--calibrate-only", "--samples", "samples.json"])
+
+
+def test_resume_collection_rejects_checkerboard_geometry_mismatch(tmp_path, monkeypatch):
+    sample_path = tmp_path / "samples.npz"
+    sample_path.touch()
+    monkeypatch.setattr(
+        cli,
+        "load_samples",
+        lambda path, fingerprint: ([_sample()], _collection_metadata((8, 6), 0.015)),
+    )
+
+    with pytest.raises(ValueError, match="checkerboard geometry"):
+        cli.load_existing_samples(sample_path, _collection_metadata(), (10, 7), 0.02)
 
 
 def test_collection_key_handler_rejects_stale_detection_and_preserves_metadata(tmp_path, monkeypatch):

--- a/tests/test_orbbec_handeye_cli.py
+++ b/tests/test_orbbec_handeye_cli.py
@@ -20,6 +20,8 @@ import orbbec_handeye_calib as cli  # noqa: E402
 def _metadata(fingerprint="camera-1"):
     return {
         "camera_fingerprint": fingerprint,
+        "serial": "ABC123",
+        "firmware": "1.2.3",
         "color_profile": "1280x720@30_RGB",
         "depth_profile": "640x576@30_Y16",
         "color_intrinsics": {
@@ -31,6 +33,15 @@ def _metadata(fingerprint="camera-1"):
             "cy": 360.0,
         },
         "color_distortion": [0.1, -0.1, 0.0, 0.0, 0.01],
+        "depth_intrinsics": {
+            "width": 640,
+            "height": 576,
+            "fx": 580.0,
+            "fy": 581.0,
+            "cx": 320.0,
+            "cy": 288.0,
+        },
+        "depth_distortion": [0.01, -0.01, 0.0, 0.0, 0.001],
         "depth_scale_m": 0.001,
         "T_color_depth_matrix": np.eye(4).reshape(-1).tolist(),
     }
@@ -326,6 +337,78 @@ def test_resume_collection_rejects_checkerboard_geometry_mismatch(tmp_path, monk
 
     with pytest.raises(ValueError, match="checkerboard geometry"):
         cli.load_existing_samples(sample_path, _collection_metadata(), (10, 7), 0.02)
+
+
+def test_resume_collection_loads_compatible_samples(tmp_path, monkeypatch):
+    sample_path = tmp_path / "samples.npz"
+    sample_path.touch()
+    samples = [_sample()]
+    monkeypatch.setattr(
+        cli,
+        "load_samples",
+        lambda path, fingerprint: (samples, _collection_metadata()),
+    )
+
+    assert cli.load_existing_samples(
+        sample_path, _collection_metadata(), (10, 7), 0.02
+    ) == samples
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        (
+            "depth_intrinsics",
+            {
+                "width": 640,
+                "height": 576,
+                "fx": 579.0,
+                "fy": 581.0,
+                "cx": 320.0,
+                "cy": 288.0,
+            },
+        ),
+        ("depth_distortion", [0.02, -0.01, 0.0, 0.0, 0.001]),
+        ("depth_scale_m", 0.002),
+        ("firmware", "1.2.4"),
+    ],
+)
+def test_resume_collection_rejects_changed_depth_calibration_before_capture(
+    tmp_path, monkeypatch, field, value
+):
+    sample_path = tmp_path / "samples.npz"
+    sample_path.touch()
+    saved_metadata = _collection_metadata()
+    saved_metadata[field] = value
+
+    class Camera:
+        metadata = _metadata()
+
+        def start(self):
+            return self
+
+        def wait_for_frames(self):
+            return SimpleNamespace(color_bgr=np.zeros((20, 20, 3), dtype=np.uint8))
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(
+        cli,
+        "load_samples",
+        lambda path, fingerprint: ([_sample()], saved_metadata),
+    )
+    monkeypatch.setattr(cli, "create_camera", lambda args: Camera())
+    monkeypatch.setattr(
+        cli, "create_nero_robot", lambda args: SimpleNamespace(disconnect=lambda: None)
+    )
+    monkeypatch.setattr(cli, "run_frame_loop", lambda *args: pytest.fail("capture started"))
+    monkeypatch.setattr(cli, "destroy_windows", lambda: None)
+
+    with pytest.raises(ValueError, match="incompatible with this camera profile"):
+        cli.run_collection(
+            cli.build_arg_parser().parse_args(["--samples", str(sample_path)])
+        )
 
 
 def test_collection_key_handler_rejects_stale_detection_and_preserves_metadata(tmp_path, monkeypatch):

--- a/tests/test_orbbec_handeye_cli.py
+++ b/tests/test_orbbec_handeye_cli.py
@@ -85,7 +85,7 @@ def test_parser_defaults_and_handeye_method_choices():
     assert args.samples == Path("orbbec_handeye_samples.npz")
     assert args.output == Path("orbbec_handeye_result.json")
     assert args.method == "TSAI"
-    assert (args.width, args.height, args.fps) == (1280, 720, 30)
+    assert (args.width, args.height, args.fps, args.frame_timeout_ms) == (1280, 720, 30, 1000)
     with pytest.raises(SystemExit):
         cli.build_arg_parser().parse_args(["--method", "NOPE"])
 

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -1,8 +1,12 @@
 """Hardware-independent tests for Orbbec hand-eye geometry helpers."""
 
+import builtins
+import json
 import math
 from pathlib import Path
 import sys
+from types import SimpleNamespace
+import zipfile
 
 import numpy as np
 import pytest
@@ -29,6 +33,33 @@ def _diverse_samples():
         _sample([0.1, 0.0, 0.0, 0.2, 0.0, 0.0], timestamp=2.0),
         _sample([0.0, 0.1, 0.0, 0.0, -0.25, 0.1], timestamp=3.0),
     ]
+
+
+def _same_axis_samples():
+    return [
+        _sample([0.00, 0.00, 0.00, 0.00, 0.00, 0.00], timestamp=1.0),
+        _sample([0.10, 0.02, 0.00, 0.20, 0.00, 0.00], timestamp=2.0),
+        _sample([0.00, 0.08, 0.03, -0.30, 0.00, 0.00], timestamp=3.0),
+        _sample([-0.04, 0.01, 0.07, 0.45, 0.00, 0.00], timestamp=4.0),
+    ]
+
+
+def _write_sample_archive(
+    path,
+    camera_fingerprint=np.asarray("camera-1"),
+    flange_poses=None,
+):
+    if flange_poses is None:
+        flange_poses = np.zeros((0, 6), dtype=np.float64)
+    np.savez_compressed(
+        path,
+        flange_poses=flange_poses,
+        target_rvecs=np.zeros((0, 3, 1), dtype=np.float64),
+        target_tvecs=np.zeros((0, 3, 1), dtype=np.float64),
+        timestamps=np.zeros((0,), dtype=np.float64),
+        camera_fingerprint=camera_fingerprint,
+        camera_metadata_json=np.asarray(json.dumps({"camera_fingerprint": "camera-1"})),
+    )
 
 
 def _synthetic_handeye_samples():
@@ -473,6 +504,32 @@ def test_sample_persistence_rejects_non_serializable_metadata(tmp_path):
         )
 
 
+def test_sample_persistence_rejects_extra_archive_members_before_loading(tmp_path):
+    path = tmp_path / "extra-member.npz"
+    _write_sample_archive(path)
+    with zipfile.ZipFile(path, "a") as archive:
+        archive.writestr("unexpected.npy", b"not an array")
+
+    with pytest.raises(ValueError, match="unexpected member"):
+        math3d.load_samples(path)
+
+
+def test_sample_persistence_rejects_archive_member_over_resource_limit(tmp_path):
+    path = tmp_path / "oversized-member.npz"
+    _write_sample_archive(path, flange_poses=np.zeros((50000, 6), dtype=np.float64))
+
+    with pytest.raises(ValueError, match="resource limit"):
+        math3d.load_samples(path)
+
+
+def test_sample_persistence_rejects_non_string_scalar_fingerprint(tmp_path):
+    path = tmp_path / "integer-fingerprint.npz"
+    _write_sample_archive(path, camera_fingerprint=np.asarray(123))
+
+    with pytest.raises(ValueError, match="fingerprint.*string"):
+        math3d.load_samples(path)
+
+
 def test_validate_sample_motion_requires_count_and_rotation_diversity():
     with pytest.raises(ValueError, match="at least 3"):
         math3d.validate_sample_motion(_diverse_samples()[:2])
@@ -488,6 +545,36 @@ def test_validate_sample_motion_reports_diverse_motion_summary():
     assert summary["sample_count"] == 3
     assert summary["max_rotation_deg"] > 5.0
     assert summary["translation_span_m"] > 0.0
+
+
+def test_validate_sample_motion_rejects_rotations_about_only_one_axis():
+    with pytest.raises(ValueError, match="non-collinear axes.*observability"):
+        math3d.validate_sample_motion(_same_axis_samples())
+
+
+def test_calibration_rejects_same_axis_rotations_before_opencv(monkeypatch):
+    fake_cv2 = SimpleNamespace(
+        CALIB_HAND_EYE_TSAI=0,
+        CALIB_HAND_EYE_PARK=1,
+        CALIB_HAND_EYE_HORAUD=2,
+        CALIB_HAND_EYE_ANDREFF=3,
+        CALIB_HAND_EYE_DANIILIDIS=4,
+        calibrateHandEye=lambda *args, **kwargs: pytest.fail("OpenCV must not run"),
+    )
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+
+    with pytest.raises(ValueError, match="non-collinear axes.*observability"):
+        math3d.calibrate_eye_in_hand(
+            _same_axis_samples(), np.eye(4), {"camera_fingerprint": "camera-1"}
+        )
+
+
+def test_validate_sample_motion_reports_conditioning_for_synthetic_samples():
+    samples, _ = _synthetic_handeye_samples()
+
+    summary = math3d.validate_sample_motion(samples)
+
+    assert summary["rotation_axis_conditioning"] >= 0.05
 
 
 def test_named_transform_serializes_inverse_and_normalized_quaternion():
@@ -511,8 +598,17 @@ def test_named_transform_serializes_inverse_and_normalized_quaternion():
     )
 
 
-@pytest.mark.parametrize("method_name", ["TSAI", "PARK"])
-def test_calibrate_eye_in_hand_recovers_deterministic_synthetic_transform(method_name):
+@pytest.mark.parametrize(
+    "method_name,atol",
+    [
+        ("TSAI", 1e-7),
+        ("PARK", 1e-7),
+        ("HORAUD", 1e-7),
+        ("ANDREFF", 1e-7),
+        ("DANIILIDIS", 1e-6),
+    ],
+)
+def test_calibrate_eye_in_hand_recovers_deterministic_synthetic_transform(method_name, atol):
     samples, expected_T_flange_color = _synthetic_handeye_samples()
     T_color_depth = math3d.pose6_to_matrix([0.01, -0.02, 0.03, 0.03, 0.01, -0.02])
 
@@ -524,9 +620,27 @@ def test_calibrate_eye_in_hand_recovers_deterministic_synthetic_transform(method
     )
 
     recovered = np.asarray(result["T_flange_color"]["matrix_row_major_4x4"]).reshape(4, 4)
-    np.testing.assert_allclose(recovered, expected_T_flange_color, atol=1e-7)
+    np.testing.assert_allclose(recovered, expected_T_flange_color, atol=atol)
     recovered_depth = np.asarray(result["T_flange_depth"]["matrix_row_major_4x4"]).reshape(4, 4)
-    np.testing.assert_allclose(recovered_depth, expected_T_flange_color @ T_color_depth, atol=1e-7)
+    np.testing.assert_allclose(
+        recovered_depth, expected_T_flange_color @ T_color_depth, atol=atol
+    )
+
+
+def test_calibration_reports_actionable_error_when_opencv_import_is_blocked(monkeypatch):
+    original_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "cv2":
+            raise ImportError("blocked for test")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    with pytest.raises(ValueError, match="OpenCV is required"):
+        math3d.calibrate_eye_in_hand(
+            _diverse_samples(), np.eye(4), {"camera_fingerprint": "camera-1"}
+        )
 
 
 def test_calibration_result_has_schema_warning_and_near_zero_consistency():

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -71,6 +71,16 @@ def test_checkerboard_points_use_inner_corners_and_metres():
         ((10, 0), 0.02),
         ((-10, 7), 0.02),
         ((10, -7), 0.02),
+        ((float("nan"), 7), 0.02),
+        ((float("inf"), 7), 0.02),
+        ((-float("inf"), 7), 0.02),
+        ((10.5, 7), 0.02),
+        ((10, 6.5), 0.02),
+        (("10", 7), 0.02),
+        ((True, 7), 0.02),
+        ((10, False), 0.02),
+        ((10,), 0.02),
+        ((10, 7, 1), 0.02),
         ((10, 7), 0.0),
         ((10, 7), -0.02),
         ((10, 7), float("nan")),
@@ -80,8 +90,16 @@ def test_checkerboard_points_use_inner_corners_and_metres():
 def test_checkerboard_rejects_invalid_dimensions_and_size(
     checkerboard, square_size_m
 ):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Checkerboard dimensions"):
         math3d.create_checkerboard_object_points(checkerboard, square_size_m)
+
+
+def test_checkerboard_accepts_integral_numpy_scalar_dimensions():
+    points = math3d.create_checkerboard_object_points(
+        (np.int64(10), np.int32(7)), 0.02
+    )
+
+    assert points.shape == (70, 3)
 
 
 def test_pose6_to_matrix_uses_zyx_rpy_and_homogeneous_translation():

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -32,9 +32,11 @@ def test_checkerboard_points_use_inner_corners_and_metres():
         ((10, -7), 0.02),
         ((10, 7), 0.0),
         ((10, 7), -0.02),
+        ((10, 7), float("nan")),
+        ((10, 7), float("inf")),
     ],
 )
-def test_checkerboard_rejects_non_positive_dimensions_and_size(
+def test_checkerboard_rejects_invalid_dimensions_and_size(
     checkerboard, square_size_m
 ):
     with pytest.raises(ValueError):
@@ -95,6 +97,54 @@ def test_invert_transform_composes_to_identity():
 
     np.testing.assert_allclose(transform @ inverse, np.eye(4), atol=1e-15)
     np.testing.assert_allclose(inverse @ transform, np.eye(4), atol=1e-15)
+
+
+@pytest.mark.parametrize(
+    "transform,error_pattern",
+    [
+        pytest.param(np.eye(3), "shape", id="wrong-shape"),
+        pytest.param(
+            np.diag([float("nan"), 1.0, 1.0, 1.0]),
+            "finite",
+            id="nonfinite",
+        ),
+        pytest.param(
+            np.array(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [1.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+            "bottom row",
+            id="bad-bottom-row",
+        ),
+        pytest.param(
+            np.diag([2.0, 1.0, 1.0, 1.0]),
+            "orthonormal",
+            id="scaled-rotation",
+        ),
+        pytest.param(
+            np.diag([-1.0, 1.0, 1.0, 1.0]),
+            "determinant",
+            id="reflection",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "operation", ["matrix_to_pose6", "invert_transform", "transform_point"]
+)
+def test_geometry_helpers_reject_malformed_rigid_transforms(
+    operation, transform, error_pattern
+):
+    function = getattr(math3d, operation)
+
+    with pytest.raises(ValueError, match=error_pattern):
+        if operation == "transform_point":
+            function(transform, [0.0, 0.0, 0.0])
+        else:
+            function(transform)
 
 
 def test_depth_pixel_to_camera_point_converts_raw_depth_to_metres():
@@ -164,6 +214,75 @@ def test_deprojection_rejects_nonfinite_focal_lengths(key, value):
         )
 
 
+@pytest.mark.parametrize("field", ["u", "v", "cx", "cy"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_deprojection_rejects_nonfinite_pixel_coordinates(field, value):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    arguments = {"u": 320.0, "v": 240.0}
+    if field in intrinsics:
+        intrinsics[field] = value
+    else:
+        arguments[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        math3d.deproject_depth_pixel(
+            arguments["u"],
+            arguments["v"],
+            1000,
+            intrinsics,
+            depth_scale_m=0.001,
+        )
+
+
+@pytest.mark.parametrize(
+    "min_depth_m", [float("nan"), float("inf"), -float("inf"), -0.01]
+)
+def test_deprojection_rejects_invalid_minimum_depth_bound(min_depth_m):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="min_depth_m"):
+        math3d.deproject_depth_pixel(
+            320,
+            240,
+            1000,
+            intrinsics,
+            depth_scale_m=0.001,
+            min_depth_m=min_depth_m,
+        )
+
+
+@pytest.mark.parametrize(
+    "max_depth_m", [float("nan"), float("inf"), -float("inf")]
+)
+def test_deprojection_rejects_nonfinite_maximum_depth_bound(max_depth_m):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="max_depth_m"):
+        math3d.deproject_depth_pixel(
+            320,
+            240,
+            1000,
+            intrinsics,
+            depth_scale_m=0.001,
+            max_depth_m=max_depth_m,
+        )
+
+
+def test_deprojection_rejects_maximum_depth_below_minimum():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="max_depth_m"):
+        math3d.deproject_depth_pixel(
+            320,
+            240,
+            1000,
+            intrinsics,
+            depth_scale_m=0.001,
+            min_depth_m=1.0,
+            max_depth_m=0.5,
+        )
+
+
 @pytest.mark.parametrize(
     "bounds",
     [
@@ -199,13 +318,23 @@ def test_deprojection_accepts_depth_at_configured_range_boundaries():
 def test_depth_pixel_to_base_uses_base_flange_then_flange_depth():
     intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
     T_flange_depth = np.eye(4)
-    T_flange_depth[:3, 3] = [0.0, 0.0, 0.1]
+    T_flange_depth[:3, :3] = [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, -1.0],
+        [0.0, 1.0, 0.0],
+    ]
+    T_flange_depth[:3, 3] = [0.1, 0.2, 0.3]
     T_base_flange = np.eye(4)
-    T_base_flange[:3, 3] = [0.5, 0.0, 0.0]
+    T_base_flange[:3, :3] = [
+        [0.0, -1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+    T_base_flange[:3, 3] = [0.5, -0.1, 0.2]
 
     point = math3d.depth_pixel_to_base(
-        320,
-        240,
+        420,
+        290,
         1000,
         intrinsics,
         0.001,
@@ -213,4 +342,5 @@ def test_depth_pixel_to_base_uses_base_flange_then_flange_depth():
         T_base_flange,
     )
 
-    np.testing.assert_allclose(point, [0.5, 0.0, 1.1])
+    # p_depth=[0.2, 0.1, 1.0], p_flange=[0.3, -0.8, 0.4].
+    np.testing.assert_allclose(point, [1.3, 0.2, 0.6])

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -14,6 +14,47 @@ sys.path.insert(0, str(NERO_DEMO_DIR))
 import orbbec_handeye_math as math3d  # noqa: E402
 
 
+def _sample(flange_pose, target_rvec=(0.0, 0.0, 0.0), target_tvec=(0.0, 0.0, 1.0), timestamp=1.0):
+    return {
+        "flange_pose": list(flange_pose),
+        "target_rvec": np.asarray(target_rvec, dtype=np.float64).reshape(3, 1),
+        "target_tvec": np.asarray(target_tvec, dtype=np.float64).reshape(3, 1),
+        "timestamp": timestamp,
+    }
+
+
+def _diverse_samples():
+    return [
+        _sample([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], timestamp=1.0),
+        _sample([0.1, 0.0, 0.0, 0.2, 0.0, 0.0], timestamp=2.0),
+        _sample([0.0, 0.1, 0.0, 0.0, -0.25, 0.1], timestamp=3.0),
+    ]
+
+
+def _synthetic_handeye_samples():
+    cv2 = pytest.importorskip("cv2")
+    if not hasattr(cv2, "calibrateHandEye"):
+        pytest.skip("OpenCV build does not provide calibrateHandEye")
+    T_flange_color = math3d.pose6_to_matrix([0.05, 0.01, 0.08, 0.1, -0.05, 0.2])
+    T_base_target = math3d.pose6_to_matrix([0.7, -0.2, 0.5, -0.3, 0.2, 0.4])
+    flange_poses = [
+        [0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        [0.10, -0.03, 0.02, 0.25, 0.10, -0.15],
+        [-0.04, 0.08, 0.06, -0.30, 0.20, 0.25],
+        [0.03, 0.06, -0.04, 0.15, -0.35, 0.30],
+        [-0.08, -0.02, 0.10, -0.20, -0.15, -0.35],
+        [0.06, 0.04, 0.03, 0.35, 0.25, 0.10],
+    ]
+    samples = []
+    for index, flange_pose in enumerate(flange_poses):
+        T_color_target = math3d.invert_transform(
+            math3d.pose6_to_matrix(flange_pose) @ T_flange_color
+        ) @ T_base_target
+        rvec, _ = cv2.Rodrigues(T_color_target[:3, :3])
+        samples.append(_sample(flange_pose, rvec, T_color_target[:3, 3], index + 1.0))
+    return samples, T_flange_color
+
+
 def test_checkerboard_points_use_inner_corners_and_metres():
     points = math3d.create_checkerboard_object_points((10, 7), 0.02)
 
@@ -344,3 +385,158 @@ def test_depth_pixel_to_base_uses_base_flange_then_flange_depth():
 
     # p_depth=[0.2, 0.1, 1.0], p_flange=[0.3, -0.8, 0.4].
     np.testing.assert_allclose(point, [1.3, 0.2, 0.6])
+
+
+def test_sample_persistence_round_trip_preserves_metadata_and_float64(tmp_path):
+    samples = _diverse_samples()
+    metadata = {
+        "camera_fingerprint": "orbbec:abc123",
+        "serial_number": "ABC123",
+        "intrinsics": {"fx": 600.0, "fy": 601.0},
+    }
+    path = tmp_path / "samples.npz"
+
+    math3d.save_samples(path, samples, metadata)
+    loaded, loaded_metadata = math3d.load_samples(path, "orbbec:abc123")
+
+    assert loaded_metadata == metadata
+    assert len(loaded) == len(samples)
+    assert loaded[0]["flange_pose"] == samples[0]["flange_pose"]
+    assert loaded[0]["target_rvec"].shape == (3, 1)
+    assert loaded[0]["target_tvec"].shape == (3, 1)
+    assert loaded[0]["target_rvec"].dtype == np.float64
+    assert loaded[0]["target_tvec"].dtype == np.float64
+    assert loaded[0]["timestamp"] == 1.0
+
+
+def test_sample_persistence_round_trips_empty_samples_with_deterministic_shapes(tmp_path):
+    path = tmp_path / "empty.npz"
+    math3d.save_samples(path, [], {"camera_fingerprint": "camera-1"})
+
+    with np.load(path, allow_pickle=False) as archive:
+        assert archive["flange_poses"].shape == (0, 6)
+        assert archive["target_rvecs"].shape == (0, 3, 1)
+        assert archive["target_tvecs"].shape == (0, 3, 1)
+        assert archive["timestamps"].shape == (0,)
+
+    samples, metadata = math3d.load_samples(path)
+    assert samples == []
+    assert metadata == {"camera_fingerprint": "camera-1"}
+
+
+def test_sample_persistence_rejects_fingerprint_mismatch_and_missing_fields(tmp_path):
+    path = tmp_path / "samples.npz"
+    math3d.save_samples(path, _diverse_samples(), {"camera_fingerprint": "camera-1"})
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        math3d.load_samples(path, expected_fingerprint="other-camera")
+
+    corrupt_path = tmp_path / "corrupt.npz"
+    np.savez_compressed(corrupt_path, flange_poses=np.zeros((0, 6)))
+    with pytest.raises(ValueError, match="missing required field"):
+        math3d.load_samples(corrupt_path)
+
+
+def test_sample_persistence_rejects_truncated_archive_with_value_error(tmp_path):
+    path = tmp_path / "truncated.npz"
+    math3d.save_samples(path, _diverse_samples(), {"camera_fingerprint": "camera-1"})
+    path.write_bytes(path.read_bytes()[:20])
+
+    with pytest.raises(ValueError, match="could not load sample archive"):
+        math3d.load_samples(path)
+
+
+def test_sample_persistence_rejects_non_serializable_metadata(tmp_path):
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        math3d.save_samples(
+            tmp_path / "samples.npz",
+            [],
+            {"camera_fingerprint": "camera-1", "unsupported": {1, 2}},
+        )
+
+
+def test_validate_sample_motion_requires_count_and_rotation_diversity():
+    with pytest.raises(ValueError, match="at least 3"):
+        math3d.validate_sample_motion(_diverse_samples()[:2])
+
+    repeated = [_sample([0.02 * index, 0.0, 0.0, 0, 0, 0]) for index in range(3)]
+    with pytest.raises(ValueError, match="rotation diversity.*15-30"):
+        math3d.validate_sample_motion(repeated)
+
+
+def test_validate_sample_motion_reports_diverse_motion_summary():
+    summary = math3d.validate_sample_motion(_diverse_samples())
+
+    assert summary["sample_count"] == 3
+    assert summary["max_rotation_deg"] > 5.0
+    assert summary["translation_span_m"] > 0.0
+
+
+def test_named_transform_serializes_inverse_and_normalized_quaternion():
+    transform = math3d.make_transform(
+        math3d.pose6_to_matrix([0, 0, 0, 0.2, -0.1, 0.4])[:3, :3],
+        [0.1, -0.2, 0.3],
+    )
+    named = math3d.named_transform("flange", "color", transform)
+    inverse = math3d.named_transform("color", "flange", math3d.invert_transform(transform))
+
+    assert named["parent_frame"] == "flange"
+    assert named["child_frame"] == "color"
+    assert len(named["matrix_row_major_4x4"]) == 16
+    assert np.isclose(np.linalg.norm(named["quaternion_xyzw"]), 1.0)
+    assert np.all(np.isfinite(np.asarray(named["pose6_xyz_rpy"])))
+    np.testing.assert_allclose(
+        np.asarray(named["matrix_row_major_4x4"]).reshape(4, 4)
+        @ np.asarray(inverse["matrix_row_major_4x4"]).reshape(4, 4),
+        np.eye(4),
+        atol=1e-15,
+    )
+
+
+@pytest.mark.parametrize("method_name", ["TSAI", "PARK"])
+def test_calibrate_eye_in_hand_recovers_deterministic_synthetic_transform(method_name):
+    samples, expected_T_flange_color = _synthetic_handeye_samples()
+    T_color_depth = math3d.pose6_to_matrix([0.01, -0.02, 0.03, 0.03, 0.01, -0.02])
+
+    result = math3d.calibrate_eye_in_hand(
+        samples,
+        T_color_depth,
+        {"camera_fingerprint": "camera-1"},
+        method_name=method_name,
+    )
+
+    recovered = np.asarray(result["T_flange_color"]["matrix_row_major_4x4"]).reshape(4, 4)
+    np.testing.assert_allclose(recovered, expected_T_flange_color, atol=1e-7)
+    recovered_depth = np.asarray(result["T_flange_depth"]["matrix_row_major_4x4"]).reshape(4, 4)
+    np.testing.assert_allclose(recovered_depth, expected_T_flange_color @ T_color_depth, atol=1e-7)
+
+
+def test_calibration_result_has_schema_warning_and_near_zero_consistency():
+    samples, _ = _synthetic_handeye_samples()
+    result = math3d.calibrate_eye_in_hand(
+        samples,
+        np.eye(4),
+        {"camera_fingerprint": "camera-1"},
+    )
+
+    assert result["schema_version"] == 1
+    assert result["sample_count"] == 6
+    assert result["checkerboard"] == {"inner_corners": [10, 7], "square_size_m": 0.02}
+    assert result["quality_warnings"]
+    assert result["consistency"]["translation_max_m"] < 1e-7
+    assert result["consistency"]["rotation_max_deg"] < 1e-5
+    assert all(np.isfinite(value) for value in result["consistency"].values())
+
+
+def test_calibration_rejects_unknown_method_and_nonfinite_sample_data():
+    samples = _diverse_samples()
+    with pytest.raises(ValueError, match="method"):
+        math3d.calibrate_eye_in_hand(
+            samples, np.eye(4), {"camera_fingerprint": "camera-1"}, method_name="BAD"
+        )
+
+    samples[0]["target_tvec"][0, 0] = float("nan")
+    with pytest.raises(ValueError, match="finite"):
+        math3d.calibrate_eye_in_hand(
+            samples, np.eye(4), {"camera_fingerprint": "camera-1"}
+        )

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -189,6 +189,29 @@ def test_invert_transform_composes_to_identity():
     np.testing.assert_allclose(inverse @ transform, np.eye(4), atol=1e-15)
 
 
+def test_rigid_transform_normalizes_valid_float32_calibration_rotation():
+    transform = np.array(
+        [
+            [0.999997258, -0.002327133, 0.000345531, -0.012587452],
+            [0.002327119, 0.999997318, 0.000041355, 0.000032290],
+            [-0.000345626, -0.000040551, 0.999999940, -0.001149079],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+
+    normalized = math3d._validate_rigid_transform(transform)
+
+    np.testing.assert_allclose(normalized[:3, 3], transform[:3, 3], atol=0.0)
+    np.testing.assert_allclose(
+        normalized[:3, :3].T @ normalized[:3, :3],
+        np.eye(3),
+        rtol=0.0,
+        atol=1e-12,
+    )
+    assert np.linalg.det(normalized[:3, :3]) == pytest.approx(1.0, abs=1e-12)
+
+
 @pytest.mark.parametrize(
     "transform,error_pattern",
     [

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -473,6 +473,54 @@ def test_sample_persistence_round_trips_empty_samples_with_deterministic_shapes(
     assert metadata == {"camera_fingerprint": "camera-1"}
 
 
+def test_save_samples_write_failure_preserves_existing_archive_and_cleans_temp(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "samples.npz"
+    previous_samples = [_sample([1.0, 2.0, 3.0, 0.1, 0.2, 0.3], timestamp=4.0)]
+    previous_metadata = {"camera_fingerprint": "previous-camera", "serial": "OLD"}
+    math3d.save_samples(path, previous_samples, previous_metadata)
+    previous_bytes = path.read_bytes()
+
+    def fail_after_temp_creation(temp_path, **fields):
+        Path(temp_path).write_bytes(b"partial archive")
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(np, "savez_compressed", fail_after_temp_creation)
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        math3d.save_samples(
+            path,
+            _diverse_samples(),
+            {"camera_fingerprint": "new-camera", "serial": "NEW"},
+        )
+
+    assert path.read_bytes() == previous_bytes
+    loaded, metadata = math3d.load_samples(path, "previous-camera")
+    assert metadata == previous_metadata
+    assert loaded[0]["flange_pose"] == previous_samples[0]["flange_pose"]
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_save_samples_replaces_existing_archive_and_cleans_temp(tmp_path):
+    path = tmp_path / "samples.npz"
+    math3d.save_samples(
+        path,
+        [_sample([1.0, 2.0, 3.0, 0.1, 0.2, 0.3], timestamp=4.0)],
+        {"camera_fingerprint": "previous-camera", "serial": "OLD"},
+    )
+
+    new_samples = _diverse_samples()
+    new_metadata = {"camera_fingerprint": "new-camera", "serial": "NEW"}
+    math3d.save_samples(path, new_samples, new_metadata)
+
+    loaded, metadata = math3d.load_samples(path, "new-camera")
+    assert metadata == new_metadata
+    assert len(loaded) == len(new_samples)
+    assert loaded[0]["flange_pose"] == new_samples[0]["flange_pose"]
+    assert list(tmp_path.iterdir()) == [path]
+
+
 def test_sample_persistence_rejects_fingerprint_mismatch_and_missing_fields(tmp_path):
     path = tmp_path / "samples.npz"
     math3d.save_samples(path, _diverse_samples(), {"camera_fingerprint": "camera-1"})

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -1,0 +1,195 @@
+"""Hardware-independent tests for Orbbec hand-eye geometry helpers."""
+
+import math
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+
+NERO_DEMO_DIR = Path(__file__).resolve().parents[1] / "pyAgxArm" / "demos" / "nero"
+sys.path.insert(0, str(NERO_DEMO_DIR))
+
+import orbbec_handeye_math as math3d  # noqa: E402
+
+
+def test_checkerboard_points_use_inner_corners_and_metres():
+    points = math3d.create_checkerboard_object_points((10, 7), 0.02)
+
+    assert points.shape == (70, 3)
+    assert np.issubdtype(points.dtype, np.floating)
+    np.testing.assert_allclose(points[0], [0.0, 0.0, 0.0])
+    np.testing.assert_allclose(points[-1], [0.18, 0.12, 0.0])
+
+
+@pytest.mark.parametrize(
+    "checkerboard,square_size_m",
+    [
+        ((0, 7), 0.02),
+        ((10, 0), 0.02),
+        ((-10, 7), 0.02),
+        ((10, -7), 0.02),
+        ((10, 7), 0.0),
+        ((10, 7), -0.02),
+    ],
+)
+def test_checkerboard_rejects_non_positive_dimensions_and_size(
+    checkerboard, square_size_m
+):
+    with pytest.raises(ValueError):
+        math3d.create_checkerboard_object_points(checkerboard, square_size_m)
+
+
+def test_pose6_to_matrix_uses_zyx_rpy_and_homogeneous_translation():
+    pose = [0.1, -0.2, 0.3, math.pi / 2.0, 0.0, math.pi / 2.0]
+
+    transform = math3d.pose6_to_matrix(pose)
+
+    roll_rotation = np.array(
+        [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]
+    )
+    yaw_rotation = np.array(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+    )
+    expected = np.eye(4)
+    expected[:3, :3] = yaw_rotation @ roll_rotation
+    expected[:3, 3] = pose[:3]
+    np.testing.assert_allclose(transform, expected, atol=1e-15)
+
+
+def test_pose6_round_trip_uses_zyx_rpy():
+    pose = [0.1, -0.2, 0.3, 0.2, -0.1, 0.4]
+
+    result = math3d.matrix_to_pose6(math3d.pose6_to_matrix(pose))
+
+    np.testing.assert_allclose(result, pose, atol=1e-9)
+
+
+@pytest.mark.parametrize("pitch", [math.pi / 2.0, -math.pi / 2.0])
+def test_matrix_to_pose6_handles_gimbal_lock(pitch):
+    transform = math3d.pose6_to_matrix([0.1, -0.2, 0.3, 0.4, pitch, -0.7])
+
+    recovered_pose = math3d.matrix_to_pose6(transform)
+
+    assert np.all(np.isfinite(recovered_pose))
+    np.testing.assert_allclose(
+        math3d.pose6_to_matrix(recovered_pose), transform, atol=1e-9
+    )
+
+
+def test_transform_point_maps_child_point_to_parent():
+    transform = math3d.pose6_to_matrix(
+        [1.0, 2.0, 3.0, 0.0, 0.0, math.pi / 2.0]
+    )
+
+    point = math3d.transform_point(transform, [1.0, 0.0, 0.0])
+
+    np.testing.assert_allclose(point, [1.0, 3.0, 3.0], atol=1e-15)
+
+
+def test_invert_transform_composes_to_identity():
+    transform = math3d.pose6_to_matrix([0.1, -0.2, 0.3, 0.2, -0.1, 0.4])
+
+    inverse = math3d.invert_transform(transform)
+
+    np.testing.assert_allclose(transform @ inverse, np.eye(4), atol=1e-15)
+    np.testing.assert_allclose(inverse @ transform, np.eye(4), atol=1e-15)
+
+
+def test_depth_pixel_to_camera_point_converts_raw_depth_to_metres():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    point = math3d.deproject_depth_pixel(
+        420, 290, 1000, intrinsics, depth_scale_m=0.001
+    )
+
+    np.testing.assert_allclose(point, [0.2, 0.1, 1.0])
+
+
+@pytest.mark.parametrize("depth_raw", [0, -1, float("nan"), float("inf")])
+def test_deprojection_rejects_invalid_depth(depth_raw):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="depth"):
+        math3d.deproject_depth_pixel(
+            320, 240, depth_raw, intrinsics, depth_scale_m=0.001
+        )
+
+
+@pytest.mark.parametrize(
+    "depth_scale_m", [0, -0.001, float("nan"), float("inf")]
+)
+def test_deprojection_rejects_scale_that_produces_invalid_depth(depth_scale_m):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="depth"):
+        math3d.deproject_depth_pixel(
+            320, 240, 1000, intrinsics, depth_scale_m=depth_scale_m
+        )
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("fx", 0.0), ("fx", -1.0), ("fy", 0.0), ("fy", -1.0)],
+)
+def test_deprojection_rejects_non_positive_focal_lengths(key, value):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    intrinsics[key] = value
+
+    with pytest.raises(ValueError, match="focal lengths"):
+        math3d.deproject_depth_pixel(
+            320, 240, 1000, intrinsics, depth_scale_m=0.001
+        )
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        {"min_depth_m": 1.01},
+        {"max_depth_m": 0.99},
+    ],
+)
+def test_deprojection_rejects_depth_outside_configured_range(bounds):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="configured range"):
+        math3d.deproject_depth_pixel(
+            320, 240, 1000, intrinsics, depth_scale_m=0.001, **bounds
+        )
+
+
+def test_deprojection_accepts_depth_at_configured_range_boundaries():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    point = math3d.deproject_depth_pixel(
+        320,
+        240,
+        1000,
+        intrinsics,
+        depth_scale_m=0.001,
+        min_depth_m=1.0,
+        max_depth_m=1.0,
+    )
+
+    np.testing.assert_allclose(point, [0.0, 0.0, 1.0])
+
+
+def test_depth_pixel_to_base_uses_base_flange_then_flange_depth():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    T_flange_depth = np.eye(4)
+    T_flange_depth[:3, 3] = [0.0, 0.0, 0.1]
+    T_base_flange = np.eye(4)
+    T_base_flange[:3, 3] = [0.5, 0.0, 0.0]
+
+    point = math3d.depth_pixel_to_base(
+        320,
+        240,
+        1000,
+        intrinsics,
+        0.001,
+        T_flange_depth,
+        T_base_flange,
+    )
+
+    np.testing.assert_allclose(point, [0.5, 0.0, 1.1])

--- a/tests/test_orbbec_handeye_math.py
+++ b/tests/test_orbbec_handeye_math.py
@@ -108,10 +108,10 @@ def test_depth_pixel_to_camera_point_converts_raw_depth_to_metres():
 
 
 @pytest.mark.parametrize("depth_raw", [0, -1, float("nan"), float("inf")])
-def test_deprojection_rejects_invalid_depth(depth_raw):
+def test_deprojection_rejects_nonfinite_or_nonpositive_raw_depth(depth_raw):
     intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
 
-    with pytest.raises(ValueError, match="depth"):
+    with pytest.raises(ValueError, match="depth_raw"):
         math3d.deproject_depth_pixel(
             320, 240, depth_raw, intrinsics, depth_scale_m=0.001
         )
@@ -120,12 +120,21 @@ def test_deprojection_rejects_invalid_depth(depth_raw):
 @pytest.mark.parametrize(
     "depth_scale_m", [0, -0.001, float("nan"), float("inf")]
 )
-def test_deprojection_rejects_scale_that_produces_invalid_depth(depth_scale_m):
+def test_deprojection_rejects_nonfinite_or_nonpositive_depth_scale(depth_scale_m):
     intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
 
-    with pytest.raises(ValueError, match="depth"):
+    with pytest.raises(ValueError, match="depth_scale_m"):
         math3d.deproject_depth_pixel(
             320, 240, 1000, intrinsics, depth_scale_m=depth_scale_m
+        )
+
+
+def test_deprojection_rejects_negative_raw_depth_with_negative_scale():
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+
+    with pytest.raises(ValueError, match="depth_raw"):
+        math3d.deproject_depth_pixel(
+            320, 240, -1000, intrinsics, depth_scale_m=-0.001
         )
 
 
@@ -138,6 +147,18 @@ def test_deprojection_rejects_non_positive_focal_lengths(key, value):
     intrinsics[key] = value
 
     with pytest.raises(ValueError, match="focal lengths"):
+        math3d.deproject_depth_pixel(
+            320, 240, 1000, intrinsics, depth_scale_m=0.001
+        )
+
+
+@pytest.mark.parametrize("key", ["fx", "fy"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_deprojection_rejects_nonfinite_focal_lengths(key, value):
+    intrinsics = {"fx": 500.0, "fy": 500.0, "cx": 320.0, "cy": 240.0}
+    intrinsics[key] = value
+
+    with pytest.raises(ValueError, match="finite and positive"):
         math3d.deproject_depth_pixel(
             320, 240, 1000, intrinsics, depth_scale_m=0.001
         )

--- a/tests/test_orbbec_v1_camera.py
+++ b/tests/test_orbbec_v1_camera.py
@@ -346,6 +346,16 @@ def test_depth_frame_to_array_keeps_raw_uint16_values():
     np.testing.assert_array_equal(depth, raw_depth)
 
 
+def test_depth_frame_to_array_preserves_uint16_ndarray_values():
+    raw_depth = np.array([[1, 255, 256, 1000, 65535]], dtype=np.uint16)
+
+    depth = camera.depth_frame_to_array(FakeFrame(5, 1, "Y16", raw_depth))
+
+    assert depth.shape == (1, 5)
+    assert depth.dtype == np.uint16
+    np.testing.assert_array_equal(depth, raw_depth)
+
+
 class FakeProfile:
     def __init__(self, width, height, fps, image_format):
         self.width = width

--- a/tests/test_orbbec_v1_camera.py
+++ b/tests/test_orbbec_v1_camera.py
@@ -1,0 +1,601 @@
+"""Hardware-independent tests for the Orbbec SDK v1 camera adapter."""
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import cv2
+
+
+NERO_DEMO_DIR = Path(__file__).resolve().parents[1] / "pyAgxArm" / "demos" / "nero"
+sys.path.insert(0, str(NERO_DEMO_DIR))
+
+import orbbec_v1_camera as camera  # noqa: E402
+
+
+def test_intrinsic_and_distortion_are_normalized_for_opencv():
+    intrinsic = SimpleNamespace(
+        width=640, height=480, fx=500.0, fy=501.0, cx=319.5, cy=239.5
+    )
+    distortion = SimpleNamespace(
+        k1=1.0, k2=2.0, k3=3.0, k4=4.0, k5=5.0, k6=6.0, p1=0.1, p2=0.2
+    )
+
+    assert camera.normalize_intrinsic(intrinsic) == {
+        "width": 640,
+        "height": 480,
+        "fx": 500.0,
+        "fy": 501.0,
+        "cx": 319.5,
+        "cy": 239.5,
+    }
+    assert camera.normalize_distortion(distortion) == [
+        1.0,
+        2.0,
+        0.1,
+        0.2,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+    ]
+
+
+def test_d2c_transform_is_depth_to_color_and_converts_mm_to_metres():
+    sdk_transform = SimpleNamespace(
+        rot=np.eye(3, dtype=np.float32).reshape(-1),
+        transform=np.array([10.0, -20.0, 30.0], dtype=np.float32),
+    )
+
+    T_color_depth = camera.normalize_d2c_transform(sdk_transform)
+
+    np.testing.assert_allclose(T_color_depth[:3, :3], np.eye(3))
+    np.testing.assert_allclose(T_color_depth[:3, 3], [0.01, -0.02, 0.03])
+
+
+def test_d2c_transform_accepts_a_valid_float32_rotation():
+    angle = np.pi / 5.0
+    rotation = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0.0],
+            [np.sin(angle), np.cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    sdk_transform = SimpleNamespace(rot=rotation.reshape(-1), transform=[0, 0, 0])
+
+    T_color_depth = camera.normalize_d2c_transform(sdk_transform)
+
+    np.testing.assert_allclose(T_color_depth[:3, :3], rotation, atol=1e-7)
+
+
+def test_depth_scale_is_converted_from_sdk_mm_to_metres():
+    assert camera.depth_scale_mm_to_m(1.0) == pytest.approx(0.001)
+
+
+class FakeProfiles:
+    def __init__(self):
+        self.requests = []
+        self.default = object()
+
+    def get_video_stream_profile(self, width, height, image_format, fps):
+        self.requests.append((width, height, image_format, fps))
+        raise RuntimeError("unsupported")
+
+    def get_default_video_stream_profile(self):
+        return self.default
+
+
+def test_profile_selection_tries_formats_in_order_then_reports_fallback():
+    profiles = FakeProfiles()
+
+    profile, used_fallback = camera.select_video_profile(
+        profiles, 1280, 720, 30, ("RGB", "MJPG")
+    )
+
+    assert profile is profiles.default
+    assert used_fallback is True
+    assert profiles.requests == [
+        (1280, 720, "RGB", 30),
+        (1280, 720, "MJPG", 30),
+    ]
+
+
+def test_profile_selection_returns_first_requested_profile_without_fallback():
+    selected = object()
+
+    class Profiles:
+        def __init__(self):
+            self.requests = []
+
+        def get_video_stream_profile(self, width, height, image_format, fps):
+            self.requests.append((width, height, image_format, fps))
+            return selected
+
+    profiles = Profiles()
+
+    profile, used_fallback = camera.select_video_profile(
+        profiles, 1280, 720, 30, ("RGB", "MJPG")
+    )
+
+    assert profile is selected
+    assert used_fallback is False
+    assert profiles.requests == [(1280, 720, "RGB", 30)]
+
+
+def test_default_depth_profile_and_profile_string_are_exact():
+    profile = SimpleNamespace(
+        get_width=lambda: 640,
+        get_height=lambda: 480,
+        get_fps=lambda: 30,
+        get_format=lambda: SimpleNamespace(name="Y16"),
+    )
+
+    class Profiles:
+        def get_default_video_stream_profile(self):
+            return profile
+
+    selected, used_fallback = camera.select_default_depth_profile(Profiles())
+
+    assert selected is profile
+    assert used_fallback is True
+    assert camera.profile_to_string(profile) == "640x480@30_Y16"
+
+
+def test_build_camera_metadata_preserves_calibration_and_profiles():
+    intrinsic = SimpleNamespace(
+        width=640, height=480, fx=500.0, fy=501.0, cx=319.5, cy=239.5
+    )
+    distortion = SimpleNamespace(
+        k1=0.1, k2=0.2, k3=0.3, k4=0.4, k5=0.5, k6=0.6, p1=0.01, p2=0.02
+    )
+    extrinsic = SimpleNamespace(
+        rot=np.eye(3, dtype=np.float32).reshape(-1),
+        transform=np.array([10.0, 0.0, 0.0], dtype=np.float32),
+    )
+    camera_param = SimpleNamespace(
+        rgb_intrinsic=intrinsic,
+        depth_intrinsic=intrinsic,
+        rgb_distortion=distortion,
+        depth_distortion=distortion,
+        transform=extrinsic,
+    )
+    device_info = SimpleNamespace(
+        get_name=lambda: "DaBai DCW",
+        get_serial_number=lambda: "ABC",
+        get_firmware_version=lambda: "2460",
+    )
+
+    metadata = camera.build_camera_metadata(
+        camera_param=camera_param,
+        device_info=device_info,
+        color_profile="1280x720@30_RGB",
+        depth_profile="640x480@30_Y16",
+        depth_scale_mm=10.0,
+    )
+
+    assert metadata["name"] == "DaBai DCW"
+    assert metadata["serial"] == "ABC"
+    assert metadata["firmware"] == "2460"
+    assert metadata["color_profile"] == "1280x720@30_RGB"
+    assert metadata["depth_profile"] == "640x480@30_Y16"
+    assert metadata["color_intrinsics"] == camera.normalize_intrinsic(intrinsic)
+    assert metadata["depth_intrinsics"] == camera.normalize_intrinsic(intrinsic)
+    assert metadata["color_distortion"] == camera.normalize_distortion(distortion)
+    assert metadata["depth_distortion"] == camera.normalize_distortion(distortion)
+    assert metadata["depth_scale_m"] == pytest.approx(0.01)
+    np.testing.assert_allclose(
+        np.array(metadata["T_color_depth_matrix"]).reshape(4, 4)[:3, 3],
+        [0.01, 0.0, 0.0],
+    )
+    assert metadata["camera_fingerprint"] == camera.camera_fingerprint(
+        "ABC", "1280x720@30_RGB", "640x480@30_Y16"
+    )
+
+
+def test_camera_fingerprint_is_stable_and_changes_with_each_input():
+    first = camera.camera_fingerprint("ABC", "1280x720@30_RGB", "640x480@30_Y16")
+
+    assert first == camera.camera_fingerprint(
+        "ABC", "1280x720@30_RGB", "640x480@30_Y16"
+    )
+    assert first != camera.camera_fingerprint("DEF", "1280x720@30_RGB", "640x480@30_Y16")
+    assert first != camera.camera_fingerprint("ABC", "640x480@30_RGB", "640x480@30_Y16")
+    assert first != camera.camera_fingerprint("ABC", "1280x720@30_RGB", "1280x720@30_Y16")
+
+
+def test_require_orbbec_sdk_explains_how_to_install_the_optional_dependency():
+    with pytest.raises(RuntimeError, match="docs/nero/orbbec_dabai_handeye\\.md"):
+        camera.require_orbbec_sdk()
+
+
+@pytest.mark.parametrize(
+    "rot,transform,error",
+    [
+        (np.eye(3).reshape(-1), [float("nan"), 0.0, 0.0], "finite"),
+        (np.diag([2.0, 1.0, 1.0]).reshape(-1), [0.0, 0.0, 0.0], "orthonormal"),
+        (np.diag([-1.0, 1.0, 1.0]).reshape(-1), [0.0, 0.0, 0.0], "determinant"),
+    ],
+)
+def test_d2c_transform_rejects_invalid_rigid_calibration(rot, transform, error):
+    extrinsic = SimpleNamespace(rot=rot, transform=transform)
+
+    with pytest.raises(ValueError, match=error):
+        camera.normalize_d2c_transform(extrinsic)
+
+
+@pytest.mark.parametrize("scale", [0.0, -1.0, float("nan"), float("inf")])
+def test_depth_scale_rejects_nonpositive_or_nonfinite_values(scale):
+    with pytest.raises(ValueError, match="finite and positive"):
+        camera.depth_scale_mm_to_m(scale)
+
+
+class FakeFormats:
+    RGB = "RGB"
+    BGR = "BGR"
+    MJPG = "MJPG"
+    YUYV = "YUYV"
+    I420 = "I420"
+    NV12 = "NV12"
+    NV21 = "NV21"
+    UYVY = "UYVY"
+
+
+FAKE_SDK = SimpleNamespace(OBFormat=FakeFormats)
+
+
+class FakeFrame:
+    def __init__(self, width, height, image_format, data, timestamp=123.0):
+        self.width = width
+        self.height = height
+        self.image_format = image_format
+        self.data = data
+        self.timestamp = timestamp
+
+    def get_width(self):
+        return self.width
+
+    def get_height(self):
+        return self.height
+
+    def get_format(self):
+        return self.image_format
+
+    def get_data(self):
+        return self.data
+
+    def get_timestamp(self):
+        return self.timestamp
+
+
+def test_frame_to_bgr_image_preserves_bgr_and_converts_rgb():
+    bgr = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
+    rgb = bgr[..., ::-1].copy()
+
+    bgr_result = camera.frame_to_bgr_image(
+        FakeFrame(2, 1, FakeFormats.BGR, bgr.tobytes()), FAKE_SDK, cv2
+    )
+    rgb_result = camera.frame_to_bgr_image(
+        FakeFrame(2, 1, FakeFormats.RGB, rgb.tobytes()), FAKE_SDK, cv2
+    )
+
+    np.testing.assert_array_equal(bgr_result, bgr)
+    np.testing.assert_array_equal(rgb_result, bgr)
+
+
+@pytest.mark.parametrize(
+    "image_format,conversion_code",
+    [
+        (FakeFormats.YUYV, cv2.COLOR_YUV2BGR_YUY2),
+        (FakeFormats.UYVY, cv2.COLOR_YUV2BGR_UYVY),
+    ],
+)
+def test_frame_to_bgr_image_converts_packed_yuv(image_format, conversion_code):
+    packed = np.array([[[16, 128], [235, 128]]], dtype=np.uint8)
+    frame = FakeFrame(2, 1, image_format, packed.tobytes())
+
+    image = camera.frame_to_bgr_image(frame, FAKE_SDK, cv2)
+
+    np.testing.assert_array_equal(image, cv2.cvtColor(packed, conversion_code))
+
+
+@pytest.mark.parametrize(
+    "image_format,conversion_code",
+    [
+        (FakeFormats.I420, cv2.COLOR_YUV2BGR_I420),
+        (FakeFormats.NV12, cv2.COLOR_YUV2BGR_NV12),
+        (FakeFormats.NV21, cv2.COLOR_YUV2BGR_NV21),
+    ],
+)
+def test_frame_to_bgr_image_converts_planar_yuv(image_format, conversion_code):
+    yuv = np.array([[16, 235], [81, 145], [128, 128]], dtype=np.uint8)
+    frame = FakeFrame(2, 2, image_format, yuv.tobytes())
+
+    image = camera.frame_to_bgr_image(frame, FAKE_SDK, cv2)
+
+    np.testing.assert_array_equal(image, cv2.cvtColor(yuv, conversion_code))
+
+
+def test_frame_to_bgr_image_decodes_mjpeg_and_rejects_unknown_formats():
+    source = np.full((2, 2, 3), [10, 20, 30], dtype=np.uint8)
+    ok, encoded = cv2.imencode(".jpg", source)
+    assert ok
+
+    decoded = camera.frame_to_bgr_image(
+        FakeFrame(2, 2, FakeFormats.MJPG, encoded.tobytes()), FAKE_SDK, cv2
+    )
+
+    assert decoded.shape == source.shape
+    with pytest.raises(RuntimeError, match="Unsupported Orbbec color format"):
+        camera.frame_to_bgr_image(
+            FakeFrame(2, 2, "H264", b""), FAKE_SDK, cv2
+        )
+
+
+def test_depth_frame_to_array_keeps_raw_uint16_values():
+    raw_depth = np.array([[0, 1000], [2000, 65535]], dtype=np.uint16)
+
+    depth = camera.depth_frame_to_array(
+        FakeFrame(2, 2, "Y16", raw_depth.tobytes())
+    )
+
+    assert depth.dtype == np.uint16
+    np.testing.assert_array_equal(depth, raw_depth)
+
+
+class FakeProfile:
+    def __init__(self, width, height, fps, image_format):
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.image_format = image_format
+
+    def get_width(self):
+        return self.width
+
+    def get_height(self):
+        return self.height
+
+    def get_fps(self):
+        return self.fps
+
+    def get_format(self):
+        return SimpleNamespace(name=self.image_format)
+
+
+class FakeLifecycleProfiles:
+    def __init__(self, selected=None, default=None):
+        self.selected = selected
+        self.default = default
+        self.requests = []
+
+    def get_video_stream_profile(self, width, height, image_format, fps):
+        self.requests.append((width, height, image_format, fps))
+        if self.selected is not None and image_format == FakeFormats.RGB:
+            return self.selected
+        raise RuntimeError("unsupported")
+
+    def get_default_video_stream_profile(self):
+        return self.default
+
+
+class FakeConfig:
+    def __init__(self):
+        self.streams = []
+        self.align_mode = None
+
+    def enable_stream(self, profile):
+        self.streams.append(profile)
+
+    def set_align_mode(self, mode):
+        self.align_mode = mode
+
+
+class FakePipeline:
+    def __init__(self, color_profiles, depth_profiles, camera_param, frameset=None):
+        self.color_profiles = color_profiles
+        self.depth_profiles = depth_profiles
+        self.camera_param = camera_param
+        self.frameset = frameset
+        self.frame_sync_enabled = False
+        self.started_config = None
+        self.stop_count = 0
+        self.start_error = None
+
+    def get_stream_profile_list(self, sensor_type):
+        if sensor_type == "COLOR_SENSOR":
+            return self.color_profiles
+        assert sensor_type == "DEPTH_SENSOR"
+        return self.depth_profiles
+
+    def enable_frame_sync(self):
+        self.frame_sync_enabled = True
+
+    def start(self, config):
+        self.started_config = config
+        if self.start_error is not None:
+            raise self.start_error
+
+    def get_camera_param(self):
+        return self.camera_param
+
+    def wait_for_frames(self, timeout_ms):
+        assert timeout_ms == 100
+        return self.frameset
+
+    def stop(self):
+        self.stop_count += 1
+
+
+class FakeFrameSet:
+    def __init__(self, color_frame, depth_frame):
+        self.color_frame = color_frame
+        self.depth_frame = depth_frame
+
+    def get_color_frame(self):
+        return self.color_frame
+
+    def get_depth_frame(self):
+        return self.depth_frame
+
+
+class FakeDepthFrame(FakeFrame):
+    def __init__(self, *args, depth_scale, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.depth_scale = depth_scale
+
+    def get_depth_scale(self):
+        return self.depth_scale
+
+
+def make_camera_param():
+    intrinsic = SimpleNamespace(
+        width=2, height=2, fx=500.0, fy=500.0, cx=1.0, cy=1.0
+    )
+    distortion = SimpleNamespace(
+        k1=0.0, k2=0.0, k3=0.0, k4=0.0, k5=0.0, k6=0.0, p1=0.0, p2=0.0
+    )
+    return SimpleNamespace(
+        rgb_intrinsic=intrinsic,
+        depth_intrinsic=intrinsic,
+        rgb_distortion=distortion,
+        depth_distortion=distortion,
+        transform=SimpleNamespace(rot=np.eye(3).reshape(-1), transform=[0, 0, 0]),
+    )
+
+
+def make_fake_sdk(devices, pipeline, config):
+    device_info = SimpleNamespace(
+        get_name=lambda: "DaBai DCW",
+        get_serial_number=lambda: "ABC",
+        get_firmware_version=lambda: "2460",
+    )
+    for device in devices:
+        device.get_device_info = lambda info=device_info: info
+
+    class DeviceList:
+        def get_count(self):
+            return len(devices)
+
+        def get_device_by_index(self, index):
+            return devices[index]
+
+        def get_device_by_serial_number(self, serial):
+            for device in devices:
+                if device.serial == serial:
+                    return device
+            return None
+
+    return SimpleNamespace(
+        Context=lambda: SimpleNamespace(query_devices=lambda: DeviceList()),
+        Pipeline=lambda device: pipeline,
+        Config=lambda: config,
+        OBSensorType=SimpleNamespace(COLOR_SENSOR="COLOR_SENSOR", DEPTH_SENSOR="DEPTH_SENSOR"),
+        OBFormat=FakeFormats,
+        OBAlignMode=SimpleNamespace(DISABLE="DISABLE"),
+    )
+
+
+def test_camera_start_wait_metadata_and_idempotent_stop(monkeypatch):
+    color_profile = FakeProfile(1280, 720, 30, "RGB")
+    depth_profile = FakeProfile(640, 480, 30, "Y16")
+    color = FakeFrame(
+        2,
+        1,
+        FakeFormats.RGB,
+        np.array([[[3, 2, 1], [6, 5, 4]]], dtype=np.uint8).tobytes(),
+        timestamp=101,
+    )
+    depth = FakeDepthFrame(
+        2,
+        2,
+        "Y16",
+        np.array([[1, 2], [3, 4]], dtype=np.uint16).tobytes(),
+        timestamp=102,
+        depth_scale=10.0,
+    )
+    pipeline = FakePipeline(
+        FakeLifecycleProfiles(selected=color_profile),
+        FakeLifecycleProfiles(default=depth_profile),
+        make_camera_param(),
+        FakeFrameSet(color, depth),
+    )
+    config = FakeConfig()
+    device = SimpleNamespace(serial="ABC")
+    sdk = make_fake_sdk([device], pipeline, config)
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+    adapter = camera.OrbbecV1Camera(serial_number="ABC")
+
+    adapter.start()
+    result = adapter.wait_for_frames()
+
+    assert pipeline.frame_sync_enabled is True
+    assert pipeline.started_config is config
+    assert config.streams == [color_profile, depth_profile]
+    assert config.align_mode == "DISABLE"
+    assert adapter.color_profile == "1280x720@30_RGB"
+    assert adapter.depth_profile == "640x480@30_Y16"
+    assert adapter.color_profile_used_fallback is False
+    assert adapter.depth_profile_used_fallback is True
+    np.testing.assert_array_equal(
+        result.color_bgr, np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
+    )
+    np.testing.assert_array_equal(result.depth_raw, np.array([[1, 2], [3, 4]], dtype=np.uint16))
+    assert result.depth_scale_m == pytest.approx(0.01)
+    assert result.color_timestamp_ms == 101
+    assert result.depth_timestamp_ms == 102
+    assert adapter.metadata["depth_scale_m"] == pytest.approx(0.01)
+    metadata_copy = adapter.metadata
+    metadata_copy["serial"] = "changed"
+    assert adapter.metadata["serial"] == "ABC"
+
+    adapter.stop()
+    adapter.stop()
+
+    assert pipeline.stop_count == 1
+
+
+def test_camera_start_requires_exactly_one_device_without_serial(monkeypatch):
+    pipeline = FakePipeline(None, None, make_camera_param())
+    sdk = make_fake_sdk(
+        [SimpleNamespace(serial="ABC"), SimpleNamespace(serial="DEF")], pipeline, FakeConfig()
+    )
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+
+    with pytest.raises(RuntimeError, match="exactly one"):
+        camera.OrbbecV1Camera().start()
+
+
+def test_camera_start_reports_missing_requested_serial(monkeypatch):
+    pipeline = FakePipeline(None, None, make_camera_param())
+    sdk = make_fake_sdk([SimpleNamespace(serial="ABC")], pipeline, FakeConfig())
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+
+    with pytest.raises(RuntimeError, match="serial 'DEF'"):
+        camera.OrbbecV1Camera(serial_number="DEF").start()
+
+
+def test_camera_start_cleans_up_partially_started_pipeline_with_actionable_error(monkeypatch):
+    color_profile = FakeProfile(1280, 720, 30, "RGB")
+    depth_profile = FakeProfile(640, 480, 30, "Y16")
+    pipeline = FakePipeline(
+        FakeLifecycleProfiles(selected=color_profile),
+        FakeLifecycleProfiles(default=depth_profile),
+        make_camera_param(),
+    )
+    pipeline.start_error = RuntimeError("SDK start failed")
+    sdk = make_fake_sdk([SimpleNamespace(serial="ABC")], pipeline, FakeConfig())
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to start Orbbec camera.*SDK start failed.*Check connection",
+    ) as error:
+        camera.OrbbecV1Camera().start()
+
+    assert pipeline.stop_count == 1
+    assert isinstance(error.value.__cause__, RuntimeError)
+    assert str(error.value.__cause__) == "SDK start failed"

--- a/tests/test_orbbec_v1_camera.py
+++ b/tests/test_orbbec_v1_camera.py
@@ -57,12 +57,11 @@ def test_d2c_transform_is_depth_to_color_and_converts_mm_to_metres():
 
 
 def test_d2c_transform_accepts_a_valid_float32_rotation():
-    angle = np.pi / 5.0
     rotation = np.array(
         [
-            [np.cos(angle), -np.sin(angle), 0.0],
-            [np.sin(angle), np.cos(angle), 0.0],
-            [0.0, 0.0, 1.0],
+            [0.999997258, -0.002327133, 0.000345531],
+            [0.002327119, 0.999997318, 0.000041355],
+            [-0.000345626, -0.000040551, 0.999999940],
         ],
         dtype=np.float32,
     )
@@ -71,10 +70,21 @@ def test_d2c_transform_accepts_a_valid_float32_rotation():
     T_color_depth = camera.normalize_d2c_transform(sdk_transform)
 
     np.testing.assert_allclose(T_color_depth[:3, :3], rotation, atol=1e-7)
+    np.testing.assert_allclose(
+        T_color_depth[:3, :3].T @ T_color_depth[:3, :3],
+        np.eye(3),
+        rtol=0.0,
+        atol=1e-12,
+    )
+    assert np.linalg.det(T_color_depth[:3, :3]) == pytest.approx(1.0, abs=1e-12)
 
 
 def test_depth_scale_is_converted_from_sdk_mm_to_metres():
     assert camera.depth_scale_mm_to_m(1.0) == pytest.approx(0.001)
+
+
+def test_camera_default_frame_timeout_allows_usb_stream_startup():
+    assert camera.OrbbecV1Camera().timeout_ms == 1000
 
 
 class FakeProfiles:
@@ -427,10 +437,13 @@ class FakePipeline:
         self.depth_profiles = depth_profiles
         self.camera_param = camera_param
         self.frameset = frameset
+        self.frame_sets = None
+        self.wait_timeouts = []
         self.frame_sync_enabled = False
         self.started_config = None
         self.stop_count = 0
         self.start_error = None
+        self.frame_sync_error = None
 
     def get_stream_profile_list(self, sensor_type):
         if sensor_type == "COLOR_SENSOR":
@@ -439,6 +452,8 @@ class FakePipeline:
         return self.depth_profiles
 
     def enable_frame_sync(self):
+        if self.frame_sync_error is not None:
+            raise self.frame_sync_error
         self.frame_sync_enabled = True
 
     def start(self, config):
@@ -450,7 +465,9 @@ class FakePipeline:
         return self.camera_param
 
     def wait_for_frames(self, timeout_ms):
-        assert timeout_ms == 100
+        self.wait_timeouts.append(timeout_ms)
+        if self.frame_sets is not None:
+            return self.frame_sets.pop(0) if self.frame_sets else None
         return self.frameset
 
     def stop(self):
@@ -610,6 +627,63 @@ def test_camera_start_wait_metadata_and_idempotent_stop(monkeypatch):
     adapter.stop()
 
     assert pipeline.stop_count == 1
+
+
+def test_camera_start_continues_when_device_does_not_support_frame_sync(monkeypatch):
+    color_profile = FakeProfile(1280, 720, 30, "RGB")
+    depth_profile = FakeProfile(640, 480, 30, "Y16")
+    pipeline = FakePipeline(
+        FakeLifecycleProfiles(selected=color_profile),
+        FakeLifecycleProfiles(default=depth_profile),
+        make_camera_param(),
+    )
+    pipeline.frame_sync_error = RuntimeError("Current device does not support frame sync!")
+    config = FakeConfig()
+    sdk = make_fake_sdk([SimpleNamespace(serial="ABC")], pipeline, config)
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+
+    adapter = camera.OrbbecV1Camera().start()
+
+    assert adapter is not None
+    assert pipeline.frame_sync_enabled is False
+    assert pipeline.started_config is config
+    assert pipeline.stop_count == 0
+
+
+def test_camera_waits_for_complete_frame_set_after_initial_depth_only_frame(monkeypatch):
+    color_profile = FakeProfile(640, 480, 30, "RGB")
+    depth_profile = FakeProfile(640, 480, 30, "Y16")
+    color = FakeFrame(
+        2,
+        1,
+        FakeFormats.RGB,
+        np.array([[[3, 2, 1], [6, 5, 4]]], dtype=np.uint8).tobytes(),
+        timestamp=101,
+    )
+    depth = FakeDepthFrame(
+        2,
+        2,
+        "Y16",
+        np.array([[1, 2], [3, 4]], dtype=np.uint16).tobytes(),
+        timestamp=102,
+        depth_scale=10.0,
+    )
+    pipeline = FakePipeline(
+        FakeLifecycleProfiles(selected=color_profile),
+        FakeLifecycleProfiles(default=depth_profile),
+        make_camera_param(),
+    )
+    pipeline.frame_sets = [FakeFrameSet(None, depth), FakeFrameSet(color, depth)]
+    config = FakeConfig()
+    sdk = make_fake_sdk([SimpleNamespace(serial="ABC")], pipeline, config)
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: sdk)
+
+    adapter = camera.OrbbecV1Camera().start()
+    result = adapter.wait_for_frames()
+
+    assert result.color_timestamp_ms == 101
+    assert result.depth_timestamp_ms == 102
+    assert len(pipeline.wait_timeouts) == 2
 
 
 def test_camera_restart_replaces_metadata_and_profiles_with_second_run(monkeypatch):

--- a/tests/test_orbbec_v1_camera.py
+++ b/tests/test_orbbec_v1_camera.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import sys
 from types import SimpleNamespace
+import builtins
 
 import numpy as np
 import pytest
@@ -207,9 +208,25 @@ def test_camera_fingerprint_is_stable_and_changes_with_each_input():
     assert first != camera.camera_fingerprint("ABC", "1280x720@30_RGB", "1280x720@30_Y16")
 
 
-def test_require_orbbec_sdk_explains_how_to_install_the_optional_dependency():
-    with pytest.raises(RuntimeError, match="docs/nero/orbbec_dabai_handeye\\.md"):
+def test_require_orbbec_sdk_explains_how_to_install_the_optional_dependency(
+    monkeypatch,
+):
+    original_import = builtins.__import__
+
+    def missing_orbbec_sdk(name, *args, **kwargs):
+        if name == "pyorbbecsdk":
+            raise ImportError("forced missing SDK")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_orbbec_sdk)
+
+    with pytest.raises(RuntimeError) as error:
         camera.require_orbbec_sdk()
+
+    message = str(error.value)
+    assert "pyorbbecsdk" in message
+    assert "docs/nero/orbbec_dabai_handeye.md" in message
+    assert "https://github.com/orbbec/pyorbbecsdk/tree/main" in message
 
 
 @pytest.mark.parametrize(
@@ -509,6 +526,33 @@ def make_fake_sdk(devices, pipeline, config):
     )
 
 
+def make_lifecycle_run(color_profile, depth_profile, depth_scale):
+    color = FakeFrame(
+        2,
+        1,
+        FakeFormats.RGB,
+        np.array([[[3, 2, 1], [6, 5, 4]]], dtype=np.uint8).tobytes(),
+        timestamp=101,
+    )
+    depth = FakeDepthFrame(
+        2,
+        2,
+        "Y16",
+        np.array([[1, 2], [3, 4]], dtype=np.uint16).tobytes(),
+        timestamp=102,
+        depth_scale=depth_scale,
+    )
+    pipeline = FakePipeline(
+        FakeLifecycleProfiles(selected=color_profile),
+        FakeLifecycleProfiles(default=depth_profile),
+        make_camera_param(),
+        FakeFrameSet(color, depth),
+    )
+    config = FakeConfig()
+    sdk = make_fake_sdk([SimpleNamespace(serial="ABC")], pipeline, config)
+    return sdk, pipeline
+
+
 def test_camera_start_wait_metadata_and_idempotent_stop(monkeypatch):
     color_profile = FakeProfile(1280, 720, 30, "RGB")
     depth_profile = FakeProfile(640, 480, 30, "Y16")
@@ -566,6 +610,65 @@ def test_camera_start_wait_metadata_and_idempotent_stop(monkeypatch):
     adapter.stop()
 
     assert pipeline.stop_count == 1
+
+
+def test_camera_restart_replaces_metadata_and_profiles_with_second_run(monkeypatch):
+    first_sdk, first_pipeline = make_lifecycle_run(
+        FakeProfile(1280, 720, 30, "RGB"),
+        FakeProfile(640, 480, 30, "Y16"),
+        depth_scale=10.0,
+    )
+    second_sdk, second_pipeline = make_lifecycle_run(
+        FakeProfile(640, 480, 30, "RGB"),
+        FakeProfile(320, 240, 15, "Y16"),
+        depth_scale=2.0,
+    )
+    sdks = iter((first_sdk, second_sdk))
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: next(sdks))
+    adapter = camera.OrbbecV1Camera()
+
+    adapter.start()
+    first = adapter.wait_for_frames()
+    adapter.stop()
+    adapter.start()
+    second = adapter.wait_for_frames()
+
+    assert first.depth_scale_m == pytest.approx(0.01)
+    assert second.depth_scale_m == pytest.approx(0.002)
+    assert adapter.metadata["depth_scale_m"] == pytest.approx(0.002)
+    assert adapter.metadata["color_profile"] == "640x480@30_RGB"
+    assert adapter.metadata["depth_profile"] == "320x240@15_Y16"
+    assert first_pipeline.stop_count == 1
+    assert second_pipeline.stop_count == 0
+
+
+def test_failed_restart_clears_previous_run_metadata_and_profiles(monkeypatch):
+    first_sdk, _ = make_lifecycle_run(
+        FakeProfile(1280, 720, 30, "RGB"),
+        FakeProfile(640, 480, 30, "Y16"),
+        depth_scale=10.0,
+    )
+    failed_sdk, failed_pipeline = make_lifecycle_run(
+        FakeProfile(640, 480, 30, "RGB"),
+        FakeProfile(320, 240, 15, "Y16"),
+        depth_scale=2.0,
+    )
+    failed_pipeline.start_error = RuntimeError("second SDK start failed")
+    sdks = iter((first_sdk, failed_sdk))
+    monkeypatch.setattr(camera, "require_orbbec_sdk", lambda: next(sdks))
+    adapter = camera.OrbbecV1Camera()
+
+    adapter.start()
+    adapter.wait_for_frames()
+    adapter.stop()
+    with pytest.raises(RuntimeError, match="second SDK start failed"):
+        adapter.start()
+
+    assert adapter.metadata is None
+    assert adapter.color_profile is None
+    assert adapter.depth_profile is None
+    assert adapter.color_profile_used_fallback is None
+    assert adapter.depth_profile_used_fallback is None
 
 
 def test_camera_start_requires_exactly_one_device_without_serial(monkeypatch):


### PR DESCRIPTION
## Summary

- Add Orbbec DaBai DCW SDK v1 camera adapter and eye-in-hand calibration CLI.
- Add raw depth pixel to Nero base-frame coordinate conversion.
- Add sample safety checks, degenerate-motion rejection, tests, and operation guide.

## Verification

- `261 passed` in the full test suite.
- `cv2.calibrateHandEye` verified with OpenCV 4.13.0.
- CLI help and Python compilation passed.

## Hardware Validation Remaining

- Install `pyorbbecsdk` v1 and verify live DaBai DCW streams.
- Verify Nero CAN traffic and flange-pose reads.
- Collect 15-30 real poses and compare a transformed depth point with a physical base-frame measurement.