### PR TITLE
feat(nero): add set_installation_pos()

### DIFF
--- a/docs/nero/nero_api.md
+++ b/docs/nero/nero_api.md
@@ -29,6 +29,7 @@
   - [Get Firmware Info — get_firmware()](#get-firmware-info--get_firmware)
 - [Parameter Settings](#parameter-settings)
   - [Set Speed Percent — set_speed_percent()](#set-speed-percent--set_speed_percent)
+  - [Set Installation Position — set_installation_pos()](#set-installation-position--set_installation_pos)
   - [Set Motion Mode — set_motion_mode()](#set-motion-mode--set_motion_mode)
 - [TCP Related](#tcp-related)
   - [Set TCP Offset — set_tcp_offset()](#set-tcp-offset--set_tcp_offset)
@@ -851,6 +852,36 @@ robot = AgxArmFactory.create_arm(cfg)
 robot.connect()
 
 robot.set_speed_percent(100)
+```
+
+---
+
+### Set Installation Position — `set_installation_pos()`
+
+**Description:** Set the installation position of the robotic arm. Supports horizontal, left-facing, and right-facing orientations.
+
+**Function Definition:**
+
+```python
+set_installation_pos(self, pos: Literal["horizontal", "left", "right"] = "horizontal") -> None
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `pos` | `str` | Installation orientation, valid values: `'horizontal'` / `'left'` / `'right'`, default: `'horizontal'` (recommended to use `robot.OPTIONS.INSTALLATION_POS.xxx` constants) |
+
+**Usage Example:**
+
+```python
+from pyAgxArm import create_agx_arm_config, AgxArmFactory, ArmModel, NeroFW
+
+cfg = create_agx_arm_config(robot=ArmModel.NERO, firmeware_version=NeroFW.DEFAULT, channel="can0")
+robot = AgxArmFactory.create_arm(cfg)
+robot.connect()
+
+robot.set_installation_pos(robot.OPTIONS.INSTALLATION_POS.HORIZONTAL)
 ```
 
 ---
@@ -2348,6 +2379,7 @@ print("set_crash_protection_rating success =", success)
   - [读取固件信息 — get_firmware()](#读取固件信息--get_firmware)
 - [参数设定](#参数设定)
   - [设定运行速度 — set_speed_percent()](#设定运行速度--set_speed_percent)
+  - [设定安装位置 — set_installation_pos()](#设定安装位置--set_installation_pos)
   - [设定运动模式 — set_motion_mode()](#设定运动模式--set_motion_mode)
 - [TCP 相关](#tcp-相关)
   - [设置 TCP 偏移 — set_tcp_offset()](#设置-tcp-偏移--set_tcp_offset)
@@ -3168,6 +3200,36 @@ robot = AgxArmFactory.create_arm(cfg)
 robot.connect()
 
 robot.set_speed_percent(100)
+```
+
+---
+
+### 设定安装位置 — `set_installation_pos()`
+
+**功能说明：** 设定机械臂安装位置，支持水平、朝左和朝右三个方向。
+
+**函数定义：**
+
+```python
+set_installation_pos(self, pos: Literal["horizontal", "left", "right"] = "horizontal") -> None
+```
+
+**参数说明：**
+
+| 名称 | 类型 | 说明 |
+| --- | --- | --- |
+| `pos` | `str` | 安装方向，可选值：`'horizontal'` / `'left'` / `'right'`，默认：`'horizontal'`（建议使用 `robot.OPTIONS.INSTALLATION_POS.xxx` 常量） |
+
+**使用示例：**
+
+```python
+from pyAgxArm import create_agx_arm_config, AgxArmFactory, ArmModel, NeroFW
+
+cfg = create_agx_arm_config(robot=ArmModel.NERO, firmeware_version=NeroFW.DEFAULT, channel="can0")
+robot = AgxArmFactory.create_arm(cfg)
+robot.connect()
+
+robot.set_installation_pos(robot.OPTIONS.INSTALLATION_POS.HORIZONTAL)
 ```
 
 ---

--- a/pyAgxArm/protocols/can_protocol/drivers/nero/default/driver.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/nero/default/driver.py
@@ -784,6 +784,42 @@ class Driver(ArmDriverAbstract):
         self._set_mode()
         self._msg_mode.move_mode = temp
 
+    def set_installation_pos(
+        self, pos: Literal['horizontal', 'left', 'right'] = 'horizontal'
+    ):
+        """Set base installation orientation.
+
+        Parameters
+        ----------
+        `pos`: Literal['horizontal', 'left', 'right']
+        - `OPTIONS.INSTALLATION_POS.HORIZONTAL`: horizontal installation (default)
+        - `OPTIONS.INSTALLATION_POS.LEFT`: left-side installation
+        - `OPTIONS.INSTALLATION_POS.RIGHT`: right-side installation
+
+        Raises
+        ------
+        ValueError
+            If `pos` is not in ['horizontal', 'left', 'right'].
+
+        Examples
+        --------
+        >>> robot.set_installation_pos(robot.OPTIONS.INSTALLATION_POS.HORIZONTAL)
+        >>> robot.set_installation_pos(robot.OPTIONS.INSTALLATION_POS.LEFT)
+        >>> robot.set_installation_pos(robot.OPTIONS.INSTALLATION_POS.RIGHT)
+        """
+        if pos not in self.OPTIONS.INSTALLATION_POS.value_list():
+            raise ValueError(
+                "Installation position should be in OPTIONS.INSTALLATION_POS: "
+                f"{self.OPTIONS.INSTALLATION_POS.value_list()}"
+            )
+        installation_pos = NeroDefaultDriverAPIProtoAdapter.installation_pos(pos)
+        self._msg_mode.installation_pos = installation_pos
+        temp = self._msg_mode.move_mode
+        self._msg_mode.move_mode = 255
+        self._set_mode()
+        self._msg_mode.installation_pos = 0
+        self._msg_mode.move_mode = temp
+
     def set_motion_mode(
         self,
         motion_mode: Literal['p', 'j', 'l', 'c', 'mit', 'js'] = 'p'

--- a/pyAgxArm/protocols/can_protocol/drivers/nero/default/parser.py
+++ b/pyAgxArm/protocols/can_protocol/drivers/nero/default/parser.py
@@ -40,6 +40,11 @@ from ....msgs.core import StrStruct
 
 class NeroDefaultDriverAPIOptions(DriverAPIOptions):
 
+    class INSTALLATION_POS(StrStruct):
+        HORIZONTAL = "horizontal"
+        LEFT = "left"
+        RIGHT = "right"
+
     class PAYLOAD(StrStruct):
         EMPTY = "empty"
         HALF = "half"
@@ -55,6 +60,12 @@ class NeroDefaultDriverAPIOptions(DriverAPIOptions):
 
 class NeroDefaultDriverAPIProtoAdapter(DriverAPIProtoAdapter):
 
+    _INSTALL_POS_CODE = {
+        NeroDefaultDriverAPIOptions.INSTALLATION_POS.HORIZONTAL: ArmMsgModeCtrl.Enums.InstallationPos.HORIZONTAL,
+        NeroDefaultDriverAPIOptions.INSTALLATION_POS.LEFT: ArmMsgModeCtrl.Enums.InstallationPos.LEFT,
+        NeroDefaultDriverAPIOptions.INSTALLATION_POS.RIGHT: ArmMsgModeCtrl.Enums.InstallationPos.RIGHT,
+    }
+
     _MOVE_CODE = {
         NeroDefaultDriverAPIOptions.MOTION_MODE.P: ArmMsgModeCtrl.Enums.MotionMode.P,
         NeroDefaultDriverAPIOptions.MOTION_MODE.J: ArmMsgModeCtrl.Enums.MotionMode.J,
@@ -68,6 +79,10 @@ class NeroDefaultDriverAPIProtoAdapter(DriverAPIProtoAdapter):
         NeroDefaultDriverAPIOptions.MOTION_MODE.MIT: ArmMsgModeCtrl.Enums.MitMode.MIT,
         NeroDefaultDriverAPIOptions.MOTION_MODE.JS: ArmMsgModeCtrl.Enums.MitMode.MIT,
     }
+
+    @classmethod
+    def installation_pos(cls, value: str) -> int:
+        return cls._INSTALL_POS_CODE[value]
 
     @classmethod
     def motion_mode(cls, value: str) -> Tuple[int, int]:


### PR DESCRIPTION
The Nero driver has no set_installation_pos(), but Piper does. The 0x151mode-ctrl message already carries the installation_pos field and the InstallationPos enum is already inherited Nero-side, so this only surfaces the API for parity. Implementation mirrors piper/default:

- NeroDefaultDriverAPIOptions.INSTALLATION_POS
- NeroDefaultDriverAPIProtoAdapter._INSTALL_POS_CODE + installation_pos()
- Driver.set_installation_pos()
- docs/nero/nero_api.md

No protocol change. Tested on V1.11 firmware.