### PR TITLE
build: include type stubs and type hints in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,8 @@ graft pyAgxArm/extensions
 graft pyAgxArm/scripts
 graft tests
 
+recursive-include pyAgxArm *.pyi py.typed
+
 prune .github
 prune .vscode
 global-exclude *.py[cod] __pycache__ .DS_Store


### PR DESCRIPTION
Add recursive inclusion of `*.pyi` and `py.typed` files in `MANIFEST.in` to ensure type information is included when building the package distribution.